### PR TITLE
Fix pagination to return complete results from all list tools

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,6 +3,7 @@ import {
   APIClientConfig,
   QueryParams,
   PaginatedResponse,
+  AllPagesOptions,
   BatchOperation,
   BatchResult,
   RequestConfig,
@@ -179,31 +180,29 @@ export class ProductboardAPIClient {
   async getAllPages<T>(
     endpoint: string,
     params?: QueryParams,
-    config?: RequestConfig,
+    options?: AllPagesOptions,
   ): Promise<T[]> {
+    const maxPages = options?.maxPages ?? 50;
     const allData: T[] = [];
-    let cursor: string | undefined;
-    let hasMore = true;
-    const limit = Number(params?.limit) || 100;
+    let pageCursor: string | undefined;
+    let page = 0;
 
-    while (hasMore) {
+    while (page < maxPages) {
       const paginatedParams: QueryParams = {
         ...params,
-        limit,
-        ...(cursor && { cursor }),
+        ...(pageCursor && { pageCursor }),
       };
 
-      const response = await this.get<PaginatedResponse<T>>(endpoint, paginatedParams, config);
+      const response = await this.get<PaginatedResponse<T>>(endpoint, paginatedParams);
       allData.push(...response.data);
+      page++;
 
-      hasMore = response.pagination.hasMore;
-      cursor = response.pagination.cursor;
+      const nextUrl = response.links?.next ?? null;
+      if (!nextUrl) break;
 
-      if (!cursor && hasMore) {
-        const pagination = response.pagination as Record<string, string | number | boolean | undefined>;
-        const currentOffset = typeof pagination.offset === 'number' ? pagination.offset : 0;
-        paginatedParams.offset = currentOffset + limit;
-      }
+      const parsed = new URL(nextUrl);
+      pageCursor = parsed.searchParams.get('pageCursor') ?? undefined;
+      if (!pageCursor) break;
     }
 
     return allData;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -10,13 +10,13 @@ export interface PaginationParams {
 
 export interface PaginatedResponse<T> {
   data: T[];
-  pagination: {
-    total?: number;
-    limit: number;
-    offset?: number;
-    cursor?: string;
-    hasMore: boolean;
+  links?: {
+    next: string | null;
   };
+}
+
+export interface AllPagesOptions {
+  maxPages?: number;
 }
 
 export interface BatchOperation {

--- a/src/tools/features/list-features.ts
+++ b/src/tools/features/list-features.ts
@@ -1,5 +1,5 @@
 import { BaseTool } from '../base.js';
-import { ProductboardAPIClient, extractResponseData } from '@api/client.js';
+import { ProductboardAPIClient } from '@api/client.js';
 import { Logger } from '@utils/logger.js';
 import { Permission, AccessLevel } from '@auth/permissions.js';
 
@@ -101,14 +101,12 @@ export class ListFeaturesTool extends BaseTool<ListFeaturesParams> {
       queryParams.tags = params.tags.join(',');
     }
 
-    const response = await this.apiClient.get('/entities', queryParams);
+    const allFeatures = await this.apiClient.getAllPages<any>('/entities', queryParams);
 
-    const features = extractResponseData(response);
-    
     // Apply client-side pagination if requested
     const requestedLimit = params.limit || 20;
     const requestedOffset = params.offset || 0;
-    const paginatedFeatures = features.slice(requestedOffset, requestedOffset + requestedLimit);
+    const paginatedFeatures = allFeatures.slice(requestedOffset, requestedOffset + requestedLimit);
     
     // Helper function to strip HTML tags
     const stripHtml = (html: string): string => {
@@ -135,7 +133,7 @@ export class ListFeaturesTool extends BaseTool<ListFeaturesParams> {
     
     // Create a text summary of the features
     const summary = formattedFeatures.length > 0
-      ? `Found ${features.length} features total, showing ${formattedFeatures.length} features:\n\n` +
+      ? `Found ${allFeatures.length} features total, showing ${formattedFeatures.length} features:\n\n` +
         formattedFeatures.map((f, i) =>
           `${i + 1}. ${f.name}\n` +
           `   ID: ${f.id}\n` +

--- a/src/tools/notes/list-notes.ts
+++ b/src/tools/notes/list-notes.ts
@@ -1,6 +1,5 @@
 import { BaseTool } from '../base.js';
 import { ProductboardAPIClient } from '@api/index.js';
-import { extractResponseData } from '@api/client.js';
 import { Logger } from '@utils/logger.js';
 import { Permission, AccessLevel } from '@auth/permissions.js';
 
@@ -80,13 +79,7 @@ export class ListNotesTool extends BaseTool<ListNotesParams> {
     if (params.date_from) queryParams.date_from = params.date_from;
     if (params.date_to) queryParams.date_to = params.date_to;
 
-    const response = await this.apiClient.makeRequest({
-      method: 'GET',
-      endpoint: '/notes',
-      params: queryParams,
-    });
-
-    const allNotes = extractResponseData(response);
+    const allNotes = await this.apiClient.getAllPages<any>('/notes', queryParams);
     const limit = params.limit || 20;
     const notes = allNotes.slice(0, limit);
 

--- a/src/tools/objectives/list-keyresults.ts
+++ b/src/tools/objectives/list-keyresults.ts
@@ -67,13 +67,7 @@ export class ListKeyResultsTool extends BaseTool<ListKeyResultsParams> {
         text: 'Key results are not available via the v2 API in this workspace. The "keyResult" entity type is not supported.',
       }],
     };
-    const response = await this.apiClient.makeRequest({
-      method: 'GET',
-      endpoint: '/entities',
-      params: queryParams,
-    });
-
-    const allKeyResults: any[] = Array.isArray((response as any)?.data) ? (response as any).data : [];
+    const allKeyResults: any[] = await this.apiClient.getAllPages<any>('/entities', queryParams);
     const limit = params.limit || 20;
     const offset = params.offset || 0;
     const keyResults = allKeyResults.slice(offset, offset + limit);

--- a/src/tools/objectives/list-objectives.ts
+++ b/src/tools/objectives/list-objectives.ts
@@ -68,13 +68,7 @@ export class ListObjectivesTool extends BaseTool<ListObjectivesParams> {
     if (params.owner_email) queryParams.owner_email = params.owner_email;
     if (params.period) queryParams.period = params.period;
 
-    const response = await this.apiClient.makeRequest({
-      method: 'GET',
-      endpoint: '/entities',
-      params: queryParams,
-    });
-
-    const allObjectives: any[] = Array.isArray((response as any)?.data) ? (response as any).data : [];
+    const allObjectives: any[] = await this.apiClient.getAllPages<any>('/entities', queryParams);
     const limit = params.limit || 20;
     const offset = params.offset || 0;
     const objectives = allObjectives.slice(offset, offset + limit);

--- a/src/tools/products/list-products.ts
+++ b/src/tools/products/list-products.ts
@@ -48,13 +48,7 @@ export class ListProductsTool extends BaseTool<ListProductsParams> {
     const queryParams: Record<string, any> = { 'type[]': 'product' };
     if (params.parent_id) queryParams.parent_id = params.parent_id;
 
-    const response = await this.apiClient.makeRequest({
-      method: 'GET',
-      endpoint: '/entities',
-      params: queryParams,
-    });
-
-    const products: any[] = Array.isArray((response as any).data) ? (response as any).data : [];
+    const products: any[] = await this.apiClient.getAllPages<any>('/entities', queryParams);
 
     const stripHtml = (s: string) => s.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
 

--- a/src/tools/releases/list-releases.ts
+++ b/src/tools/releases/list-releases.ts
@@ -68,13 +68,7 @@ export class ListReleasesTool extends BaseTool<ListReleasesParams> {
     if (params.date_from) queryParams.date_from = params.date_from;
     if (params.date_to) queryParams.date_to = params.date_to;
 
-    const response = await this.apiClient.makeRequest({
-      method: 'GET',
-      endpoint: '/entities',
-      params: queryParams,
-    });
-
-    const allReleases: any[] = Array.isArray((response as any)?.data) ? (response as any).data : [];
+    const allReleases: any[] = await this.apiClient.getAllPages<any>('/entities', queryParams);
     const limit = params.limit || 20;
     const offset = params.offset || 0;
     const releases = allReleases.slice(offset, offset + limit);

--- a/tests/integration/tools/tool-registration.test.ts
+++ b/tests/integration/tools/tool-registration.test.ts
@@ -26,6 +26,7 @@ describe('Tool Registration Integration', () => {
       put: jest.fn(),
       patch: jest.fn(),
       delete: jest.fn(),
+      getAllPages: jest.fn(),
     } as any;
 
     mockLogger = {

--- a/tests/unit/api/client.test.ts
+++ b/tests/unit/api/client.test.ts
@@ -180,47 +180,44 @@ describe('ProductboardAPIClient', () => {
   });
 
   describe('Pagination Support', () => {
-    it('should handle cursor-based pagination', async () => {
+    it('should follow links.next for cursor-based pagination', async () => {
       const page1 = {
         data: [{ id: '1', name: 'Feature 1' }],
-        pagination: { hasMore: true, cursor: 'cursor1' }
+        links: { next: `${BASE_URL}/features?pageCursor=cursor1` },
       };
-      
+
       const page2 = {
         data: [{ id: '2', name: 'Feature 2' }],
-        pagination: { hasMore: false, cursor: null }
+        links: { next: null },
       };
 
       nock(BASE_URL)
         .get('/features')
-        .query({ limit: 1 })
         .reply(200, page1);
 
       nock(BASE_URL)
         .get('/features')
-        .query({ limit: 1, cursor: 'cursor1' })
+        .query({ pageCursor: 'cursor1' })
         .reply(200, page2);
 
-      const result = await client.getAllPages('/features', { limit: 1 });
+      const result = await client.getAllPages('/features');
 
       expect(result).toHaveLength(2);
       expect((result[0] as any).id).toBe('1');
       expect((result[1] as any).id).toBe('2');
     });
 
-    it('should handle offset-based pagination', async () => {
-      // Simplify the test to just test that it can handle a single page with offset
+    it('should stop when links.next is absent', async () => {
       const page1 = {
         data: [{ id: '1', name: 'Feature 1' }],
-        pagination: { hasMore: false, offset: 0 }
+        links: { next: null },
       };
 
       nock(BASE_URL)
         .get('/features')
-        .query({ limit: 1 })
         .reply(200, page1);
 
-      const result = await client.getAllPages('/features', { limit: 1 });
+      const result = await client.getAllPages('/features');
 
       expect(result).toHaveLength(1);
       expect((result[0] as any).id).toBe('1');

--- a/tests/unit/tools/features/list-features.test.ts
+++ b/tests/unit/tools/features/list-features.test.ts
@@ -7,23 +7,21 @@ describe('ListFeaturesTool', () => {
   let mockClient: jest.Mocked<ProductboardAPIClient>;
   let mockLogger: any;
 
-  // v2 API format: features are wrapped in fields
-  const mockFeatureDataV2 = {
-    data: [
-      {
-        id: 'feat_123456',
-        fields: { name: 'User Authentication Feature', description: 'Implement OAuth2', status: { name: 'in_progress' }, owner: { email: 'john@example.com' } },
-        createdAt: '2024-01-15T10:00:00Z',
-        updatedAt: '2024-01-20T14:30:00Z',
-      },
-      {
-        id: 'feat_234567',
-        fields: { name: 'Payment Integration', description: 'Integrate Stripe', status: { name: 'new' }, owner: { email: 'jane@example.com' } },
-        createdAt: '2024-01-16T11:00:00Z',
-        updatedAt: '2024-01-16T11:00:00Z',
-      },
-    ],
-  };
+  // v2 API format: features are wrapped in fields (flat array from getAllPages)
+  const mockFeatureDataV2 = [
+    {
+      id: 'feat_123456',
+      fields: { name: 'User Authentication Feature', description: 'Implement OAuth2', status: { name: 'in_progress' }, owner: { email: 'john@example.com' } },
+      createdAt: '2024-01-15T10:00:00Z',
+      updatedAt: '2024-01-20T14:30:00Z',
+    },
+    {
+      id: 'feat_234567',
+      fields: { name: 'Payment Integration', description: 'Integrate Stripe', status: { name: 'new' }, owner: { email: 'jane@example.com' } },
+      createdAt: '2024-01-16T11:00:00Z',
+      updatedAt: '2024-01-16T11:00:00Z',
+    },
+  ];
 
   beforeEach(() => {
     mockClient = {
@@ -32,6 +30,7 @@ describe('ListFeaturesTool', () => {
       put: jest.fn(),
       delete: jest.fn(),
       patch: jest.fn(),
+      getAllPages: jest.fn(),
     } as unknown as jest.Mocked<ProductboardAPIClient>;
 
     mockLogger = {
@@ -123,12 +122,12 @@ describe('ListFeaturesTool', () => {
 
   describe('execute', () => {
     it('should list features with default parameters', async () => {
-      mockClient.get.mockResolvedValueOnce(mockFeatureDataV2);
+      mockClient.getAllPages.mockResolvedValueOnce(mockFeatureDataV2);
 
       const result = await tool.execute({});
 
       // v2 API: uses /entities with type[]=feature
-      expect(mockClient.get).toHaveBeenCalledWith('/entities', { 'type[]': 'feature' });
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'feature' });
       // Result should be MCP content format
       expect(result).toHaveProperty('content');
       expect(result.content[0]).toHaveProperty('type', 'text');
@@ -144,11 +143,11 @@ describe('ListFeaturesTool', () => {
         search: 'authentication',
       };
 
-      mockClient.get.mockResolvedValueOnce(mockFeatureDataV2);
+      mockClient.getAllPages.mockResolvedValueOnce(mockFeatureDataV2);
 
       await tool.execute(filters);
 
-      expect(mockClient.get).toHaveBeenCalledWith('/entities', {
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', {
           'type[]': 'feature',
           status: 'in_progress',
           product_id: 'prod_789',
@@ -159,16 +158,14 @@ describe('ListFeaturesTool', () => {
     });
 
     it('should handle empty results', async () => {
-      const emptyResponse = { data: [] };
-
-      mockClient.get.mockResolvedValueOnce(emptyResponse);
+      mockClient.getAllPages.mockResolvedValueOnce([]);
 
       const result = await tool.execute({});
       expect(result.content[0].text).toBe('No features found.');
     });
 
     it('should handle API errors gracefully', async () => {
-      mockClient.get.mockRejectedValueOnce(new Error('Network error'));
+      mockClient.getAllPages.mockRejectedValueOnce(new Error('Network error'));
 
       const result = await tool.execute({});
       const parsed = JSON.parse(result.content[0].text);
@@ -178,7 +175,7 @@ describe('ListFeaturesTool', () => {
     it('should handle rate limiting', async () => {
       const error = new Error('Rate limited');
       (error as any).response = { status: 429, data: {} };
-      mockClient.get.mockRejectedValueOnce(error);
+      mockClient.getAllPages.mockRejectedValueOnce(error);
 
       const result = await tool.execute({});
       const parsed = JSON.parse(result.content[0].text);
@@ -195,7 +192,7 @@ describe('ListFeaturesTool', () => {
 
   describe('response transformation', () => {
     it('should return MCP content with feature names', async () => {
-      mockClient.get.mockResolvedValueOnce(mockFeatureDataV2);
+      mockClient.getAllPages.mockResolvedValueOnce(mockFeatureDataV2);
 
       const result = await tool.execute({});
       const text = result.content[0].text;
@@ -210,7 +207,7 @@ describe('ListFeaturesTool', () => {
         { id: 'feat_2', fields: { name: 'Feature 2' } },
       ];
 
-      mockClient.get.mockResolvedValueOnce(arrayResponse);
+      mockClient.getAllPages.mockResolvedValueOnce(arrayResponse);
 
       const result = await tool.execute({});
       const text = result.content[0].text;
@@ -220,14 +217,12 @@ describe('ListFeaturesTool', () => {
     });
 
     it('should apply client-side pagination', async () => {
-      const manyFeatures = {
-        data: Array.from({ length: 5 }, (_, i) => ({
-          id: `feat_${i}`,
-          fields: { name: `Feature ${i}` },
-        })),
-      };
+      const manyFeatures = Array.from({ length: 5 }, (_, i) => ({
+        id: `feat_${i}`,
+        fields: { name: `Feature ${i}` },
+      }));
 
-      mockClient.get.mockResolvedValueOnce(manyFeatures);
+      mockClient.getAllPages.mockResolvedValueOnce(manyFeatures);
 
       const result = await tool.execute({ limit: 2, offset: 1 });
       const text = result.content[0].text;

--- a/tests/unit/tools/notes/list-notes.test.ts
+++ b/tests/unit/tools/notes/list-notes.test.ts
@@ -12,6 +12,7 @@ describe('ListNotesTool', () => {
   beforeEach(() => {
     mockApiClient = {
       makeRequest: jest.fn(),
+      getAllPages: jest.fn(),
     } as any;
 
     mockLogger = {
@@ -87,18 +88,11 @@ describe('ListNotesTool', () => {
     ];
 
     it('should list notes with default parameters', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: mockNotes,
-        links: { next: null },
-      });
+      mockApiClient.getAllPages.mockResolvedValue(mockNotes);
 
       const result = await tool.execute({});
 
-      expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/notes',
-        params: {},
-      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', {});
 
       expect(result.content[0].type).toBe('text');
       expect(result.content[0].text).toContain('Found 2 notes');
@@ -111,112 +105,67 @@ describe('ListNotesTool', () => {
     it('should filter by feature_id', async () => {
       const featureNotes = [mockNotes[0]];
 
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: featureNotes,
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue(featureNotes);
 
       const result = await tool.execute({ feature_id: 'feat-123' });
 
-      expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/notes',
-        params: { feature_id: 'feat-123' },
-      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { feature_id: 'feat-123' });
 
       expect(result.content[0].text).toContain('Found 1 notes');
     });
 
     it('should filter by customer_email', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: [mockNotes[0]],
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue([mockNotes[0]]);
 
       await tool.execute({ customer_email: 'customer1@example.com' });
 
-      expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/notes',
-        params: { customer_email: 'customer1@example.com' },
-      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { customer_email: 'customer1@example.com' });
     });
 
     it('should filter by company_name', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: mockNotes,
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue(mockNotes);
 
       await tool.execute({ company_name: 'Acme Corp' });
 
-      expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/notes',
-        params: { company_name: 'Acme Corp' },
-      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { company_name: 'Acme Corp' });
     });
 
     it('should filter by tags', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: mockNotes,
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue(mockNotes);
 
       await tool.execute({ tags: ['important', 'feature-request'] });
 
-      expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/notes',
-        params: { tags: ['important', 'feature-request'] },
-      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { tags: ['important', 'feature-request'] });
     });
 
     it('should filter by date range', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: mockNotes,
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue(mockNotes);
 
       await tool.execute({
         date_from: '2025-01-01',
         date_to: '2025-01-31',
       });
 
-      expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/notes',
-        params: {
-          date_from: '2025-01-01',
-          date_to: '2025-01-31',
-        },
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', {
+        date_from: '2025-01-01',
+        date_to: '2025-01-31',
       });
     });
 
     it('should respect custom limit', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: mockNotes,
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue(mockNotes);
 
       const result = await tool.execute({ limit: 1 });
 
       // limit is applied client-side, not sent to API
-      expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/notes',
-        params: {},
-      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', {});
 
       // Only 1 note returned due to client-side limit
       expect(result.content[0].text).toContain('showing 1');
     });
 
     it('should handle pagination', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: mockNotes,
-        links: { next: '/notes?offset=20' },
-      });
+      mockApiClient.getAllPages.mockResolvedValue(mockNotes);
 
       const result = await tool.execute({});
 
@@ -236,10 +185,7 @@ describe('ListNotesTool', () => {
     });
 
     it('should handle empty results', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: [],
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue([]);
 
       const result = await tool.execute({});
 
@@ -247,7 +193,7 @@ describe('ListNotesTool', () => {
     });
 
     it('should handle API errors', async () => {
-      mockApiClient.makeRequest.mockRejectedValue(new Error('API Error'));
+      mockApiClient.getAllPages.mockRejectedValue(new Error('API Error'));
 
       const result = await tool.execute({});
       const parsed = JSON.parse(result.content[0].text);

--- a/tests/unit/tools/objectives/list-keyresults.test.ts
+++ b/tests/unit/tools/objectives/list-keyresults.test.ts
@@ -16,6 +16,7 @@ describe('ListKeyResultsTool', () => {
       delete: jest.fn(),
       patch: jest.fn(),
       makeRequest: jest.fn(),
+      getAllPages: jest.fn(),
     } as unknown as jest.Mocked<ProductboardAPIClient>;
 
     mockLogger = {

--- a/tests/unit/tools/objectives/list-objectives.test.ts
+++ b/tests/unit/tools/objectives/list-objectives.test.ts
@@ -30,6 +30,7 @@ describe('ListObjectivesTool', () => {
       delete: jest.fn(),
       patch: jest.fn(),
       makeRequest: jest.fn(),
+      getAllPages: jest.fn(),
     } as unknown as jest.Mocked<ProductboardAPIClient>;
 
     mockLogger = {
@@ -128,15 +129,11 @@ describe('ListObjectivesTool', () => {
 
   describe('execute', () => {
     it('should list objectives with no filters', async () => {
-      mockClient.makeRequest.mockResolvedValueOnce({ data: mockObjectives });
+      mockClient.getAllPages.mockResolvedValueOnce(mockObjectives);
 
       const result = await tool.execute({});
 
-      expect(mockClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/entities',
-        params: { 'type[]': 'objective' },
-      });
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'objective' });
 
       expect(result.content[0].type).toBe('text');
       expect(result.content[0].text).toContain('Increase User Engagement');
@@ -152,19 +149,15 @@ describe('ListObjectivesTool', () => {
         offset: 0,
       };
 
-      mockClient.makeRequest.mockResolvedValueOnce({ data: [mockObjectives[0]] });
+      mockClient.getAllPages.mockResolvedValueOnce([mockObjectives[0]]);
 
       const result = await tool.execute(input);
 
-      expect(mockClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/entities',
-        params: {
-          'type[]': 'objective',
-          status: 'active',
-          owner_email: 'jane.doe@example.com',
-          period: 'quarter',
-        },
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'objective',
+        status: 'active',
+        owner_email: 'jane.doe@example.com',
+        period: 'quarter',
       });
 
       expect(result.content[0].text).toContain('Increase User Engagement');
@@ -173,21 +166,17 @@ describe('ListObjectivesTool', () => {
     it('should handle partial filters', async () => {
       const input = { status: 'completed' as const, limit: 5 };
 
-      mockClient.makeRequest.mockResolvedValueOnce({ data: [] });
+      mockClient.getAllPages.mockResolvedValueOnce([]);
 
       const result = await tool.execute(input);
 
-      expect(mockClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/entities',
-        params: { 'type[]': 'objective', status: 'completed' },
-      });
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'objective', status: 'completed' });
 
       expect(result.content[0].text).toBe('No objectives found.');
     });
 
     it('should handle API errors gracefully', async () => {
-      mockClient.makeRequest.mockRejectedValueOnce(new Error('API Error'));
+      mockClient.getAllPages.mockRejectedValueOnce(new Error('API Error'));
       const result = await tool.execute({});
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.success).toBe(false);
@@ -196,7 +185,7 @@ describe('ListObjectivesTool', () => {
     it('should handle authentication errors', async () => {
       const error = new Error('Authentication failed');
       (error as any).response = { status: 401, data: {} };
-      mockClient.makeRequest.mockRejectedValueOnce(error);
+      mockClient.getAllPages.mockRejectedValueOnce(error);
       const result = await tool.execute({});
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.success).toBe(false);
@@ -205,7 +194,7 @@ describe('ListObjectivesTool', () => {
     it('should handle forbidden errors', async () => {
       const error = new Error('Insufficient permissions');
       (error as any).response = { status: 403, data: {} };
-      mockClient.makeRequest.mockRejectedValueOnce(error);
+      mockClient.getAllPages.mockRejectedValueOnce(error);
       const result = await tool.execute({});
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.success).toBe(false);
@@ -221,17 +210,15 @@ describe('ListObjectivesTool', () => {
 
   describe('response transformation', () => {
     it('should transform API response correctly', async () => {
-      const apiResponse = {
-        data: [
-          {
-            id: 'obj_123',
-            fields: { name: 'Test Objective', description: 'Test Description', status: { name: 'active' } },
-            createdAt: '2024-01-01T00:00:00Z',
-          },
-        ],
-      };
+      const apiResponse = [
+        {
+          id: 'obj_123',
+          fields: { name: 'Test Objective', description: 'Test Description', status: { name: 'active' } },
+          createdAt: '2024-01-01T00:00:00Z',
+        },
+      ];
 
-      mockClient.makeRequest.mockResolvedValueOnce(apiResponse);
+      mockClient.getAllPages.mockResolvedValueOnce(apiResponse);
 
       const result = await tool.execute({});
 
@@ -241,7 +228,7 @@ describe('ListObjectivesTool', () => {
     });
 
     it('should handle empty results', async () => {
-      mockClient.makeRequest.mockResolvedValueOnce({ data: [] });
+      mockClient.getAllPages.mockResolvedValueOnce([]);
       const result = await tool.execute({});
       expect(result.content[0].text).toBe('No objectives found.');
     });

--- a/tests/unit/tools/products/list-products.test.ts
+++ b/tests/unit/tools/products/list-products.test.ts
@@ -10,6 +10,7 @@ describe('ListProductsTool', () => {
   beforeEach(() => {
     mockApiClient = {
       makeRequest: jest.fn(),
+      getAllPages: jest.fn(),
     } as any;
 
     mockLogger = {
@@ -64,18 +65,11 @@ describe('ListProductsTool', () => {
     ];
 
     it('should list all products successfully', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: mockProducts,
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue(mockProducts);
 
       const result = await tool.execute({});
 
-      expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/entities',
-        params: { 'type[]': 'product' },
-      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'product' });
 
       expect(result.content[0].type).toBe('text');
       expect(result.content[0].text).toContain('Found 2 products');
@@ -93,36 +87,22 @@ describe('ListProductsTool', () => {
         },
       ];
 
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: subProducts,
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue(subProducts);
 
       const result = await tool.execute({ parent_id: 'prod-1' });
 
-      expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/entities',
-        params: { 'type[]': 'product', parent_id: 'prod-1' },
-      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'product', parent_id: 'prod-1' });
 
       expect(result.content[0].text).toContain('Sub Product 1');
     });
 
     it('should include components when requested', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: mockProducts,
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue(mockProducts);
 
       const result = await tool.execute({ include_components: true });
 
       // include_components is not forwarded to API (not a supported param)
-      expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/entities',
-        params: { 'type[]': 'product' },
-      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'product' });
 
       expect(result.content[0].text).toContain('Product A');
     });
@@ -136,10 +116,7 @@ describe('ListProductsTool', () => {
         },
       ];
 
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: allProducts,
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue(allProducts);
 
       const result = await tool.execute({ include_archived: true });
 
@@ -148,10 +125,7 @@ describe('ListProductsTool', () => {
     });
 
     it('should handle empty results', async () => {
-      mockApiClient.makeRequest.mockResolvedValue({
-        data: [],
-        links: {},
-      });
+      mockApiClient.getAllPages.mockResolvedValue([]);
 
       const result = await tool.execute({});
 
@@ -159,7 +133,7 @@ describe('ListProductsTool', () => {
     });
 
     it('should handle API errors', async () => {
-      mockApiClient.makeRequest.mockRejectedValue(new Error('API Error'));
+      mockApiClient.getAllPages.mockRejectedValue(new Error('API Error'));
 
       const result = await tool.execute({});
       const parsed = JSON.parse(result.content[0].text);

--- a/tests/unit/tools/releases/list-releases.test.ts
+++ b/tests/unit/tools/releases/list-releases.test.ts
@@ -30,6 +30,7 @@ describe('ListReleasesTool', () => {
       delete: jest.fn(),
       patch: jest.fn(),
       makeRequest: jest.fn(),
+      getAllPages: jest.fn(),
     } as unknown as jest.Mocked<ProductboardAPIClient>;
 
     mockLogger = {
@@ -121,15 +122,11 @@ describe('ListReleasesTool', () => {
 
   describe('execute', () => {
     it('should list releases without filters', async () => {
-      mockClient.makeRequest.mockResolvedValueOnce({ data: mockReleases });
+      mockClient.getAllPages.mockResolvedValueOnce(mockReleases);
 
       const result = await tool.execute({});
 
-      expect(mockClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/entities',
-        params: { 'type[]': 'release' },
-      });
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'release' });
 
       expect(result.content[0].type).toBe('text');
       expect(result.content[0].text).toContain('v1.0.0');
@@ -146,20 +143,16 @@ describe('ListReleasesTool', () => {
         offset: 0,
       };
 
-      mockClient.makeRequest.mockResolvedValueOnce({ data: [mockReleases[1]] });
+      mockClient.getAllPages.mockResolvedValueOnce([mockReleases[1]]);
 
       const result = await tool.execute(input);
 
       // limit and offset are NOT sent to the API (client-side only)
-      expect(mockClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/entities',
-        params: {
-          'type[]': 'release',
-          status: 'in_progress',
-          date_from: '2024-01-01',
-          date_to: '2024-12-31',
-        },
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'release',
+        status: 'in_progress',
+        date_from: '2024-01-01',
+        date_to: '2024-12-31',
       });
 
       expect(result.content[0].text).toContain('v2.0.0');
@@ -171,21 +164,17 @@ describe('ListReleasesTool', () => {
         limit: 10,
       };
 
-      mockClient.makeRequest.mockResolvedValueOnce({ data: [] });
+      mockClient.getAllPages.mockResolvedValueOnce([]);
 
       const result = await tool.execute(input);
 
-      expect(mockClient.makeRequest).toHaveBeenCalledWith({
-        method: 'GET',
-        endpoint: '/entities',
-        params: { 'type[]': 'release', status: 'released' },
-      });
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'release', status: 'released' });
 
       expect(result.content[0].text).toBe('No releases found.');
     });
 
     it('should handle API errors gracefully', async () => {
-      mockClient.makeRequest.mockRejectedValueOnce(new Error('API Error'));
+      mockClient.getAllPages.mockRejectedValueOnce(new Error('API Error'));
 
       const result = await tool.execute({});
       const parsed = JSON.parse(result.content[0].text);
@@ -195,7 +184,7 @@ describe('ListReleasesTool', () => {
     it('should handle authentication errors', async () => {
       const error = new Error('Authentication failed');
       (error as any).response = { status: 401, data: {} };
-      mockClient.makeRequest.mockRejectedValueOnce(error);
+      mockClient.getAllPages.mockRejectedValueOnce(error);
 
       const result = await tool.execute({});
       const parsed = JSON.parse(result.content[0].text);
@@ -212,7 +201,7 @@ describe('ListReleasesTool', () => {
 
   describe('response transformation', () => {
     it('should transform API response correctly', async () => {
-      mockClient.makeRequest.mockResolvedValueOnce({ data: mockReleases });
+      mockClient.getAllPages.mockResolvedValueOnce(mockReleases);
 
       const result = await tool.execute({});
 


### PR DESCRIPTION
## Summary

List tools only returned one page of results (50–100 items) with no indication there was more. Trying to get some notes (i.e. all unprocessed) only ever returned 50, even when there were more.

All list tools now return complete datasets by paginating through every page. `getAllPages()` was rewritten to follow the v2 `links.next` format, with a 50-page default cap.

Productboard is deprecating v1 API endpoints on July 8, so all changes across this and the related PRs target v2 exclusively.

## Changes

- Rewrote `getAllPages()` to follow `links.next` URLs and extract `pageCursor` from each, instead of expecting a response shape no Productboard endpoint actually returns
- Added a configurable page cap (default 50) to prevent runaway pagination
- Updated `PaginatedResponse<T>` type to match the real v2 format: `{ data: T[], links: { next: string | null } }`
- Switched all list tools (`products`, `objectives`, `releases`, `key results`) from `makeRequest()` to `getAllPages()` so they paginate correctly too

## Test plan

- [ ] Run `npm test` — all 280 tests pass
- [ ] Verify `getAllPages()` follows multiple pages when `links.next` is present
- [ ] Verify pagination stops when `links.next` is null or page cap is reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>