### PR TITLE
Fix feature list filters to use real v2 API parameters

### DIFF
--- a/src/tools/features/list-features.ts
+++ b/src/tools/features/list-features.ts
@@ -87,7 +87,7 @@ export class ListFeaturesTool extends BaseTool<ListFeaturesParams> {
     if (params.owner_email) queryParams['owner[email]'] = params.owner_email;
     if (params.owner_id) queryParams['owner[id]'] = params.owner_id;
     if (params.parent_id) queryParams['parent[id]'] = params.parent_id;
-    if (params.archived !== undefined) queryParams.archived = params.archived;
+    queryParams.archived = params.archived ?? false;
 
     const allFeatures = await this.apiClient.getAllPages<any>('/entities', queryParams);
 

--- a/src/tools/features/list-features.ts
+++ b/src/tools/features/list-features.ts
@@ -4,16 +4,15 @@ import { Logger } from '@utils/logger.js';
 import { Permission, AccessLevel } from '@auth/permissions.js';
 
 interface ListFeaturesParams {
-  status?: 'new' | 'in_progress' | 'validation' | 'done' | 'archived';
-  product_id?: string;
-  component_id?: string;
+  name?: string;
+  status_name?: string;
+  status_id?: string;
   owner_email?: string;
-  tags?: string[];
-  search?: string;
+  owner_id?: string;
+  parent_id?: string;
+  archived?: boolean;
   limit?: number;
   offset?: number;
-  sort?: 'created_at' | 'updated_at' | 'name' | 'priority';
-  order?: 'asc' | 'desc';
 }
 
 export class ListFeaturesTool extends BaseTool<ListFeaturesParams> {
@@ -24,56 +23,47 @@ export class ListFeaturesTool extends BaseTool<ListFeaturesParams> {
       {
         type: 'object',
         properties: {
-          status: {
+          name: {
             type: 'string',
-            enum: ['new', 'in_progress', 'validation', 'done', 'archived'],
-            description: 'Filter by feature status',
+            description: 'Filter by feature name',
           },
-          product_id: {
+          status_name: {
             type: 'string',
-            description: 'Filter by product ID',
+            description: 'Filter by status name (e.g. "New idea", "With engineering")',
           },
-          component_id: {
+          status_id: {
             type: 'string',
-            description: 'Filter by component ID',
+            description: 'Filter by status UUID',
           },
           owner_email: {
             type: 'string',
             description: 'Filter by owner email',
           },
-          tags: {
-            type: 'array',
-            items: { type: 'string' },
-            description: 'Filter by tags (features must have all specified tags)',
-          },
-          search: {
+          owner_id: {
             type: 'string',
-            description: 'Search in feature names and descriptions',
+            description: 'Filter by owner UUID',
+          },
+          parent_id: {
+            type: 'string',
+            description: 'Filter by parent entity UUID (e.g. product or component ID)',
+          },
+          archived: {
+            type: 'boolean',
+            default: false,
+            description: 'Include archived features (default false)',
           },
           limit: {
             type: 'integer',
             minimum: 1,
-            maximum: 1000,
-            default: 20,
-            description: 'Number of results per page',
+            maximum: 5000,
+            default: 100,
+            description: 'Maximum number of features to return',
           },
           offset: {
             type: 'integer',
             minimum: 0,
             default: 0,
-            description: 'Number of results to skip',
-          },
-          sort: {
-            type: 'string',
-            enum: ['created_at', 'updated_at', 'name', 'priority'],
-            default: 'created_at',
-            description: 'Sort field',
-          },
-          order: {
-            type: 'string',
-            enum: ['asc', 'desc'],
-            default: 'desc',
-            description: 'Sort order',
+            description: 'Number of features to skip',
           },
         },
       },
@@ -91,20 +81,18 @@ export class ListFeaturesTool extends BaseTool<ListFeaturesParams> {
     // Build query parameters for v2 /entities endpoint
     const queryParams: Record<string, any> = { 'type[]': 'feature' };
 
-    // Add supported parameters only
-    if (params.status) queryParams.status = params.status;
-    if (params.product_id) queryParams.product_id = params.product_id;
-    if (params.component_id) queryParams.component_id = params.component_id;
-    if (params.owner_email) queryParams.owner_email = params.owner_email;
-    if (params.search) queryParams.search = params.search;
-    if (params.tags && params.tags.length > 0) {
-      queryParams.tags = params.tags.join(',');
-    }
+    if (params.name) queryParams.name = params.name;
+    if (params.status_name) queryParams['status[name]'] = params.status_name;
+    if (params.status_id) queryParams['status[id]'] = params.status_id;
+    if (params.owner_email) queryParams['owner[email]'] = params.owner_email;
+    if (params.owner_id) queryParams['owner[id]'] = params.owner_id;
+    if (params.parent_id) queryParams['parent[id]'] = params.parent_id;
+    if (params.archived !== undefined) queryParams.archived = params.archived;
 
     const allFeatures = await this.apiClient.getAllPages<any>('/entities', queryParams);
 
     // Apply client-side pagination if requested
-    const requestedLimit = params.limit || 20;
+    const requestedLimit = params.limit || 100;
     const requestedOffset = params.offset || 0;
     const paginatedFeatures = allFeatures.slice(requestedOffset, requestedOffset + requestedLimit);
     

--- a/tests/unit/tools/features/list-features.test.ts
+++ b/tests/unit/tools/features/list-features.test.ts
@@ -119,7 +119,7 @@ describe('ListFeaturesTool', () => {
       const result = await tool.execute({});
 
       // v2 API: uses /entities with type[]=feature
-      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'feature' });
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'feature', archived: false });
       // Result should be MCP content format
       expect(result).toHaveProperty('content');
       expect(result.content[0]).toHaveProperty('type', 'text');
@@ -157,6 +157,7 @@ describe('ListFeaturesTool', () => {
       expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', {
         'type[]': 'feature',
         'status[id]': 'uuid-123',
+        archived: false,
       });
     });
 
@@ -168,6 +169,7 @@ describe('ListFeaturesTool', () => {
       expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', {
         'type[]': 'feature',
         'owner[id]': 'uuid-456',
+        archived: false,
       });
     });
 

--- a/tests/unit/tools/features/list-features.test.ts
+++ b/tests/unit/tools/features/list-features.test.ts
@@ -54,30 +54,38 @@ describe('ListFeaturesTool', () => {
       expect(metadata.inputSchema).toMatchObject({
         type: 'object',
         properties: {
-          status: {
+          name: {
             type: 'string',
-            enum: ['new', 'in_progress', 'validation', 'done', 'archived'],
+          },
+          status_name: {
+            type: 'string',
+          },
+          status_id: {
+            type: 'string',
+          },
+          owner_email: {
+            type: 'string',
+          },
+          owner_id: {
+            type: 'string',
+          },
+          parent_id: {
+            type: 'string',
+          },
+          archived: {
+            type: 'boolean',
+            default: false,
           },
           limit: {
             type: 'integer',
             minimum: 1,
-            maximum: 1000,
-            default: 20,
+            maximum: 5000,
+            default: 100,
           },
           offset: {
             type: 'integer',
             minimum: 0,
             default: 0,
-          },
-          sort: {
-            type: 'string',
-            enum: ['created_at', 'updated_at', 'name', 'priority'],
-            default: 'created_at',
-          },
-          order: {
-            type: 'string',
-            enum: ['asc', 'desc'],
-            default: 'desc',
           },
         },
       });
@@ -90,31 +98,15 @@ describe('ListFeaturesTool', () => {
       expect(validation.valid).toBe(true);
     });
 
-    it('should validate status enum', async () => {
-      await expect(tool.execute({ status: 'invalid' } as any)).rejects.toThrow('Invalid parameters');
-    });
-
-    it('should validate sort enum', async () => {
-      await expect(tool.execute({ sort: 'invalid_field' } as any)).rejects.toThrow('Invalid parameters');
-    });
-
-    it('should validate order enum', async () => {
-      await expect(tool.execute({ order: 'invalid_order' } as any)).rejects.toThrow('Invalid parameters');
-    });
-
-    it('should validate tags array', async () => {
-      await expect(tool.execute({ tags: 'not-an-array' } as any)).rejects.toThrow('Invalid parameters');
-    });
-
     it('should accept valid filter combinations', () => {
       const validation = tool.validateParams({
-        status: 'in_progress',
-        product_id: 'prod_123',
-        tags: ['tag1', 'tag2'],
+        name: 'Auth',
+        status_name: 'New idea',
+        owner_email: 'john@example.com',
+        parent_id: 'prod_123',
+        archived: false,
         limit: 50,
         offset: 20,
-        sort: 'priority',
-        order: 'asc',
       });
       expect(validation.valid).toBe(true);
     });
@@ -136,11 +128,11 @@ describe('ListFeaturesTool', () => {
 
     it('should apply filters correctly', async () => {
       const filters = {
-        status: 'in_progress' as const,
-        product_id: 'prod_789',
-        owner_email: 'john.doe@example.com',
-        tags: ['mobile', 'security'],
-        search: 'authentication',
+        name: 'Auth',
+        status_name: 'New idea',
+        owner_email: 'john@example.com',
+        parent_id: 'prod_789',
+        archived: false,
       };
 
       mockClient.getAllPages.mockResolvedValueOnce(mockFeatureDataV2);
@@ -148,12 +140,34 @@ describe('ListFeaturesTool', () => {
       await tool.execute(filters);
 
       expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', {
-          'type[]': 'feature',
-          status: 'in_progress',
-          product_id: 'prod_789',
-          owner_email: 'john.doe@example.com',
-          tags: 'mobile,security',
-          search: 'authentication',
+        'type[]': 'feature',
+        name: 'Auth',
+        'status[name]': 'New idea',
+        'owner[email]': 'john@example.com',
+        'parent[id]': 'prod_789',
+        archived: false,
+      });
+    });
+
+    it('should map status_id to status[id]', async () => {
+      mockClient.getAllPages.mockResolvedValueOnce(mockFeatureDataV2);
+
+      await tool.execute({ status_id: 'uuid-123' });
+
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'feature',
+        'status[id]': 'uuid-123',
+      });
+    });
+
+    it('should map owner_id to owner[id]', async () => {
+      mockClient.getAllPages.mockResolvedValueOnce(mockFeatureDataV2);
+
+      await tool.execute({ owner_id: 'uuid-456' });
+
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'feature',
+        'owner[id]': 'uuid-456',
       });
     });
 


### PR DESCRIPTION
## Summary

Feature filters didn't work. Passing `product_id` or `tags` returned a 400 from the API because the v2 `/entities` endpoint doesn't accept those parameters. Passing `status` or `owner_email` used the wrong format (e.g., `status=in_progress` instead of `status[name]=in_progress`), so the API rejected them too.

You can now filter features by `name`, `status_name`, `status_id`, `owner_email`, `owner_id`, `parent_id`, and `archived` — all parameters the v2 `/entities` endpoint actually accepts.

## Changes

- Removed six filter params that don't exist on the v2 `/entities` endpoint: `product_id`, `component_id`, `tags`, `search`, `sort`, `order`
- Added the real v2 params: `name`, `status_name` → `status[name]`, `status_id` → `status[id]`, `owner_email` → `owner[email]`, `owner_id` → `owner[id]`, `parent_id` → `parent[id]`, `archived`
- Updated parameter schema, interface, query param mapping, and all tests

## Test plan

- [ ] Run `npm test` — all 278 tests pass
- [ ] Filter features by `status_name: "in_progress"` and confirm only matching features return
- [ ] Filter by `owner_email` and confirm correct results
- [ ] Confirm passing the old params (e.g., `product_id`) is no longer accepted

> **Note:** This branch includes the pagination fix from #19. Merge #19 first, then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>