### PR TITLE
Fix note list filters to use real v2 API parameters

### DIFF
--- a/src/tools/notes/list-notes.ts
+++ b/src/tools/notes/list-notes.ts
@@ -4,12 +4,19 @@ import { Logger } from '@utils/logger.js';
 import { Permission, AccessLevel } from '@auth/permissions.js';
 
 interface ListNotesParams {
-  feature_id?: string;
-  customer_email?: string;
-  company_name?: string;
-  tags?: string[];
-  date_from?: string;
-  date_to?: string;
+  processed?: boolean;
+  archived?: boolean;
+  owner_email?: string;
+  owner_id?: string;
+  creator_email?: string;
+  creator_id?: string;
+  source_record_id?: string;
+  metadata_source_system?: string;
+  metadata_source_record_id?: string;
+  created_from?: string;
+  created_to?: string;
+  updated_from?: string;
+  updated_to?: string;
   limit?: number;
 }
 
@@ -21,38 +28,67 @@ export class ListNotesTool extends BaseTool<ListNotesParams> {
       {
         type: 'object',
         properties: {
-          feature_id: {
-            type: 'string',
-            description: 'Filter notes linked to a specific feature',
+          processed: {
+            type: 'boolean',
+            description: 'Filter by processed state',
           },
-          customer_email: {
-            type: 'string',
-            description: 'Filter by customer email',
+          archived: {
+            type: 'boolean',
+            description: 'Filter by archived state. Note: archived notes always return processed=false regardless of actual state',
           },
-          company_name: {
+          owner_email: {
             type: 'string',
-            description: 'Filter by company',
+            description: 'Filter by owner email address',
           },
-          tags: {
-            type: 'array',
-            items: { type: 'string' },
-            description: 'Filter by tags',
-          },
-          date_from: {
+          owner_id: {
             type: 'string',
-            format: 'date',
-            description: 'Filter notes created after this date',
+            description: 'Filter by owner ID',
           },
-          date_to: {
+          creator_email: {
             type: 'string',
-            format: 'date',
-            description: 'Filter notes created before this date',
+            description: 'Filter by creator email address',
+          },
+          creator_id: {
+            type: 'string',
+            description: 'Filter by creator ID',
+          },
+          source_record_id: {
+            type: 'string',
+            description: 'Filter by source record ID',
+          },
+          metadata_source_system: {
+            type: 'string',
+            description: 'Filter by metadata source system',
+          },
+          metadata_source_record_id: {
+            type: 'string',
+            description: 'Filter by metadata source record ID',
+          },
+          created_from: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Filter notes created from this date-time',
+          },
+          created_to: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Filter notes created up to this date-time',
+          },
+          updated_from: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Filter notes updated from this date-time',
+          },
+          updated_to: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Filter notes updated up to this date-time',
           },
           limit: {
             type: 'integer',
             minimum: 1,
-            maximum: 100,
-            default: 20,
+            maximum: 5000,
+            default: 100,
           },
         },
       },
@@ -69,18 +105,24 @@ export class ListNotesTool extends BaseTool<ListNotesParams> {
   protected async executeInternal(params: ListNotesParams = {}): Promise<unknown> {
     this.logger.info('Listing notes');
 
-    // Only include filters supported by the Productboard API
     const queryParams: Record<string, any> = {};
 
-    if (params.feature_id) queryParams.feature_id = params.feature_id;
-    if (params.customer_email) queryParams.customer_email = params.customer_email;
-    if (params.company_name) queryParams.company_name = params.company_name;
-    if (params.tags) queryParams.tags = params.tags;
-    if (params.date_from) queryParams.date_from = params.date_from;
-    if (params.date_to) queryParams.date_to = params.date_to;
+    if (params.processed !== undefined) queryParams.processed = params.processed;
+    if (params.archived !== undefined) queryParams.archived = params.archived;
+    if (params.owner_email) queryParams['owner[email]'] = params.owner_email;
+    if (params.owner_id) queryParams['owner[id]'] = params.owner_id;
+    if (params.creator_email) queryParams['creator[email]'] = params.creator_email;
+    if (params.creator_id) queryParams['creator[id]'] = params.creator_id;
+    if (params.source_record_id) queryParams['source[recordId]'] = params.source_record_id;
+    if (params.metadata_source_system) queryParams['metadata[source][system]'] = params.metadata_source_system;
+    if (params.metadata_source_record_id) queryParams['metadata[source][recordId]'] = params.metadata_source_record_id;
+    if (params.created_from) queryParams.createdFrom = params.created_from;
+    if (params.created_to) queryParams.createdTo = params.created_to;
+    if (params.updated_from) queryParams.updatedFrom = params.updated_from;
+    if (params.updated_to) queryParams.updatedTo = params.updated_to;
 
     const allNotes = await this.apiClient.getAllPages<any>('/notes', queryParams);
-    const limit = params.limit || 20;
+    const limit = params.limit || 100;
     const notes = allNotes.slice(0, limit);
 
     const stripHtml = (s: string) => s
@@ -103,7 +145,7 @@ export class ListNotesTool extends BaseTool<ListNotesParams> {
         formattedNotes.map((n, i) =>
           `${i + 1}. ${n.title}\n` +
           `   Owner: ${n.owner}\n` +
-          `   Content: ${n.content.substring(0, 150)}${n.content.length > 150 ? '...' : ''}\n` +
+          `   Content: ${n.content}\n` +
           `   Tags: ${n.tags.length > 0 ? n.tags.join(', ') : 'None'}\n`
         ).join('\n')
       : 'No notes found.';

--- a/tests/unit/tools/notes/list-notes.test.ts
+++ b/tests/unit/tools/notes/list-notes.test.ts
@@ -35,38 +35,67 @@ describe('ListNotesTool', () => {
       expect(tool.parameters).toMatchObject({
         type: 'object',
         properties: {
-          feature_id: {
-            type: 'string',
-            description: 'Filter notes linked to a specific feature',
+          processed: {
+            type: 'boolean',
+            description: 'Filter by processed state',
           },
-          customer_email: {
-            type: 'string',
-            description: 'Filter by customer email',
+          archived: {
+            type: 'boolean',
+            description: expect.stringContaining('archived'),
           },
-          company_name: {
+          owner_email: {
             type: 'string',
-            description: 'Filter by company',
+            description: 'Filter by owner email address',
           },
-          tags: {
-            type: 'array',
-            items: { type: 'string' },
-            description: 'Filter by tags',
-          },
-          date_from: {
+          owner_id: {
             type: 'string',
-            format: 'date',
-            description: 'Filter notes created after this date',
+            description: 'Filter by owner ID',
           },
-          date_to: {
+          creator_email: {
             type: 'string',
-            format: 'date',
-            description: 'Filter notes created before this date',
+            description: 'Filter by creator email address',
+          },
+          creator_id: {
+            type: 'string',
+            description: 'Filter by creator ID',
+          },
+          source_record_id: {
+            type: 'string',
+            description: 'Filter by source record ID',
+          },
+          metadata_source_system: {
+            type: 'string',
+            description: 'Filter by metadata source system',
+          },
+          metadata_source_record_id: {
+            type: 'string',
+            description: 'Filter by metadata source record ID',
+          },
+          created_from: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Filter notes created from this date-time',
+          },
+          created_to: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Filter notes created up to this date-time',
+          },
+          updated_from: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Filter notes updated from this date-time',
+          },
+          updated_to: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Filter notes updated up to this date-time',
           },
           limit: {
             type: 'integer',
             minimum: 1,
-            maximum: 100,
-            default: 20,
+            maximum: 5000,
+            default: 100,
           },
         },
       });
@@ -77,12 +106,12 @@ describe('ListNotesTool', () => {
     const mockNotes = [
       {
         id: 'note-1',
-        fields: { name: 'First feedback', content: '<p>First feedback</p>', owner: { email: 'customer1@example.com' }, tags: [] },
+        fields: { name: 'First feedback', content: '<p>First feedback</p>', owner: { email: 'owner1@example.com' }, tags: [] },
         createdAt: '2025-01-15T00:00:00Z',
       },
       {
         id: 'note-2',
-        fields: { name: 'Second feedback', content: '<p>Second feedback</p>', owner: { email: 'customer2@example.com' }, tags: [] },
+        fields: { name: 'Second feedback', content: '<p>Second feedback</p>', owner: { email: 'owner2@example.com' }, tags: [] },
         createdAt: '2025-01-14T00:00:00Z',
       },
     ];
@@ -102,53 +131,98 @@ describe('ListNotesTool', () => {
       expect(mockLogger.info).toHaveBeenCalledWith('Listing notes');
     });
 
-    it('should filter by feature_id', async () => {
-      const featureNotes = [mockNotes[0]];
+    it('should filter by processed', async () => {
+      mockApiClient.getAllPages.mockResolvedValue(mockNotes);
 
-      mockApiClient.getAllPages.mockResolvedValue(featureNotes);
+      await tool.execute({ processed: true });
 
-      const result = await tool.execute({ feature_id: 'feat-123' });
-
-      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { feature_id: 'feat-123' });
-
-      expect(result.content[0].text).toContain('Found 1 notes');
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { processed: true });
     });
 
-    it('should filter by customer_email', async () => {
+    it('should filter by archived', async () => {
+      mockApiClient.getAllPages.mockResolvedValue(mockNotes);
+
+      await tool.execute({ archived: false });
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { archived: false });
+    });
+
+    it('should filter by owner_email', async () => {
       mockApiClient.getAllPages.mockResolvedValue([mockNotes[0]]);
 
-      await tool.execute({ customer_email: 'customer1@example.com' });
+      await tool.execute({ owner_email: 'owner1@example.com' });
 
-      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { customer_email: 'customer1@example.com' });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { 'owner[email]': 'owner1@example.com' });
     });
 
-    it('should filter by company_name', async () => {
+    it('should filter by owner_id', async () => {
+      mockApiClient.getAllPages.mockResolvedValue([mockNotes[0]]);
+
+      await tool.execute({ owner_id: 'user-123' });
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { 'owner[id]': 'user-123' });
+    });
+
+    it('should filter by creator_email', async () => {
+      mockApiClient.getAllPages.mockResolvedValue([mockNotes[0]]);
+
+      await tool.execute({ creator_email: 'creator@example.com' });
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { 'creator[email]': 'creator@example.com' });
+    });
+
+    it('should filter by creator_id', async () => {
+      mockApiClient.getAllPages.mockResolvedValue([mockNotes[0]]);
+
+      await tool.execute({ creator_id: 'creator-456' });
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { 'creator[id]': 'creator-456' });
+    });
+
+    it('should filter by source_record_id', async () => {
       mockApiClient.getAllPages.mockResolvedValue(mockNotes);
 
-      await tool.execute({ company_name: 'Acme Corp' });
+      await tool.execute({ source_record_id: 'src-789' });
 
-      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { company_name: 'Acme Corp' });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { 'source[recordId]': 'src-789' });
     });
 
-    it('should filter by tags', async () => {
+    it('should filter by metadata source fields', async () => {
       mockApiClient.getAllPages.mockResolvedValue(mockNotes);
 
-      await tool.execute({ tags: ['important', 'feature-request'] });
+      await tool.execute({ metadata_source_system: 'zendesk', metadata_source_record_id: 'zd-100' });
 
-      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', { tags: ['important', 'feature-request'] });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', {
+        'metadata[source][system]': 'zendesk',
+        'metadata[source][recordId]': 'zd-100',
+      });
     });
 
-    it('should filter by date range', async () => {
+    it('should filter by created date range', async () => {
       mockApiClient.getAllPages.mockResolvedValue(mockNotes);
 
       await tool.execute({
-        date_from: '2025-01-01',
-        date_to: '2025-01-31',
+        created_from: '2025-01-01T00:00:00Z',
+        created_to: '2025-01-31T23:59:59Z',
       });
 
       expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', {
-        date_from: '2025-01-01',
-        date_to: '2025-01-31',
+        createdFrom: '2025-01-01T00:00:00Z',
+        createdTo: '2025-01-31T23:59:59Z',
+      });
+    });
+
+    it('should filter by updated date range', async () => {
+      mockApiClient.getAllPages.mockResolvedValue(mockNotes);
+
+      await tool.execute({
+        updated_from: '2025-02-01T00:00:00Z',
+        updated_to: '2025-02-28T23:59:59Z',
+      });
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/notes', {
+        updatedFrom: '2025-02-01T00:00:00Z',
+        updatedTo: '2025-02-28T23:59:59Z',
       });
     });
 
@@ -175,13 +249,7 @@ describe('ListNotesTool', () => {
 
     it('should validate limit range', async () => {
       await expect(tool.execute({ limit: 0 })).rejects.toThrow('Invalid parameters');
-      await expect(tool.execute({ limit: 101 })).rejects.toThrow('Invalid parameters');
-    });
-
-    it('should validate date format', async () => {
-      await expect(
-        tool.execute({ date_from: 'invalid-date' })
-      ).rejects.toThrow('Invalid parameters');
+      await expect(tool.execute({ limit: 5001 })).rejects.toThrow('Invalid parameters');
     });
 
     it('should handle empty results', async () => {


### PR DESCRIPTION
## Summary

Note filters looked like they worked but didn't. Passing `feature_id` or `customer_email` didn't error — the v2 `/notes` endpoint silently ignored them and returned unfiltered results. So filtering by a specific customer's email returned every note in the workspace.

You can now filter notes by `processed`, `archived`, `creator_email`, `creator_id`, `owner_email`, `owner_id`, `source_record_id`, metadata source fields, and date ranges (`created_from`, `created_to`, `updated_from`, `updated_to`). Full note content is also returned instead of truncating at 150 characters.

## Changes

- Removed three silently-ignored params: `feature_id`, `customer_email`, `company_name`
- Removed `tags` filter (v2 `/notes` endpoint doesn't support it; `POST /notes/search` does, but that's a separate tool)
- Added all real v2 `/notes` params: `processed`, `archived`, `owner[email]`, `owner[id]`, `creator[email]`, `creator[id]`, `source[recordId]`, `metadata[source][system]`, `metadata[source][recordId]`, `createdFrom`, `createdTo`, `updatedFrom`, `updatedTo`
- Changed date params from `date_from`/`date_to` (ISO date) to `created_from`/`created_to` and `updated_from`/`updated_to` (ISO datetime)
- Removed 150-character content truncation so full note content is returned
- Updated parameter schema, interface, query param mapping, and all tests

## Test plan

- [ ] Run `npm test` — all 284 tests pass
- [ ] Filter notes by `processed: false` and confirm only unprocessed notes return
- [ ] Filter by `creator_email` and confirm correct results
- [ ] Filter by date range using `created_from`/`created_to` and confirm results fall within range
- [ ] Confirm full note content is visible (not cut off at 150 chars)

> **Note:** This branch includes the pagination fix from #19. Merge #19 first, then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>