### PR TITLE
Remove leftover debug regex from email comparison

### DIFF
--- a/src/tools/notes/create-note.ts
+++ b/src/tools/notes/create-note.ts
@@ -231,7 +231,7 @@ export class CreateNoteTool extends BaseTool<CreateNoteParams> {
     });
 
     const emailMatch = byEmail.find((u: any) => {
-      const userEmail = u.fields?.email?.toLowerCase().replace(/dat$/, '');
+      const userEmail = u.fields?.email?.toLowerCase();
       return userEmail === email.toLowerCase();
     });
 


### PR DESCRIPTION
## Summary

Addresses feedback from #22 — the `.replace(/dat$/, '')` strips a literal "dat" suffix from emails before comparison, which was left over from debugging. This could cause mismatches for emails that legitimately end in "dat".

## Changes

- Removed `.replace(/dat$/, '')` from the email comparison in `create-note.ts:234`

## Test plan

- [ ] Run `npm test` — all 288 tests pass
- [ ] Create a note with a customer whose email ends in "dat" — should match correctly now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>