### PR TITLE
fix: correct manifest.json to valid MCPB schema (closes #10)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,32 @@
 {
+  "manifest_version": "0.1",
   "name": "productboard-mcp",
+  "display_name": "Productboard",
   "version": "0.2.1",
   "description": "MCP server for the Productboard API. Enables AI assistants (Claude, Cursor, etc.) to interact with your Productboard workspace.",
-  "author": "Enreign",
+  "author": {
+    "name": "Enreign",
+    "url": "https://github.com/Enreign"
+  },
   "license": "MIT",
-  "repository": "https://github.com/Enreign/productboard-mcp",
-  "runtime": "node",
-  "entrypoint": "server/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Enreign/productboard-mcp"
+  },
+  "homepage": "https://github.com/Enreign/productboard-mcp",
+  "server": {
+    "type": "node",
+    "entry_point": "dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/dist/index.js"],
+      "env": {
+        "PRODUCTBOARD_API_TOKEN": "${user_config.PRODUCTBOARD_API_TOKEN}",
+        "PRODUCTBOARD_AUTH_TYPE": "${user_config.PRODUCTBOARD_AUTH_TYPE}",
+        "LOG_LEVEL": "${user_config.LOG_LEVEL}"
+      }
+    }
+  },
   "tools": [
     { "name": "pb_feature_list", "description": "List features with filtering" },
     { "name": "pb_feature_get", "description": "Get a feature by ID" },
@@ -30,23 +50,34 @@
     { "name": "pb_release_status_update", "description": "Update release status" },
     { "name": "pb_release_timeline", "description": "Get release timeline" }
   ],
-  "configSchema": {
+  "keywords": ["productboard", "mcp", "product-management"],
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "node": ">=18.0.0"
+    }
+  },
+  "user_config": {
     "PRODUCTBOARD_API_TOKEN": {
       "type": "string",
+      "title": "Productboard API Token",
+      "description": "Your Productboard API token. Get it from Profile & Settings → API Access in your Productboard workspace.",
       "required": true,
-      "description": "Your Productboard API token. Get it from Profile & Settings → API Access in your Productboard workspace."
+      "sensitive": true
     },
     "PRODUCTBOARD_AUTH_TYPE": {
       "type": "string",
+      "title": "Auth Type",
+      "description": "Auth type: bearer or oauth2",
       "required": false,
-      "default": "bearer",
-      "description": "Auth type: bearer or oauth2"
+      "default": "bearer"
     },
     "LOG_LEVEL": {
       "type": "string",
+      "title": "Log Level",
+      "description": "Log level: trace, debug, info, warn, error, fatal. Keep at error for MCP clients.",
       "required": false,
-      "default": "error",
-      "description": "Log level: trace, debug, info, warn, error, fatal. Keep at error for MCP clients."
+      "default": "error"
     }
   }
 }


### PR DESCRIPTION
## Summary

Issue #10 reports Claude Desktop rejecting the extension with:

> Failed to preview extension: Invalid manifest: Invalid input

Root cause: the repo's `manifest.json` (which gets bundled into the `.mcpb` release) uses a non-standard schema (`runtime`, `entrypoint`, `configSchema`). Claude Desktop validates against the official MCPB manifest schema and fails fast.

Running the official validator on main confirms:

\`\`\`
npx @anthropic-ai/mcpb validate manifest.json

ERROR: Manifest validation failed:
  - dxt_version: Required
  - author: Expected object, received string
  - repository: Expected object, received string
  - server: Required
  - Unrecognized key(s): 'runtime', 'entrypoint', 'configSchema'
\`\`\`

## Changes

Rewrites `manifest.json` to MCPB 0.1:
- `manifest_version: "0.1"` added
- `author` / `repository` as objects
- `server.{type,entry_point,mcp_config}` — with proper node config, args using \`\${__dirname}\`, and env variable wiring from `user_config`
- `configSchema` → `user_config` (different shape: `title`, `description`, `sensitive`, `default`)
- `entry_point` corrected from `server/index.js` (doesn't exist) to `dist/index.js`

## Verification

\`\`\`
npx @anthropic-ai/mcpb validate manifest.json
Manifest schema validation passes!
\`\`\`

## Follow-up

End users on v0.2.1 still see the broken manifest until a new release is cut. After merging this PR, cut a v0.2.2 (or v0.3.0) release with a freshly-built `.mcpb` — something along:

\`\`\`bash
npm ci --omit=dev
npm run build
npx -y @anthropic-ai/mcpb pack . productboard-mcp-v0.2.2.mcpb
gh release create v0.2.2 productboard-mcp-v0.2.2.mcpb
\`\`\`

Closes #10.