### PR TITLE
Add pb_customer_lookup tool for finding existing customers

### DIFF
--- a/src/tools/customers/index.ts
+++ b/src/tools/customers/index.ts
@@ -1,0 +1,1 @@
+export { LookupCustomersTool } from './lookup-customers.js';

--- a/src/tools/customers/lookup-customers.ts
+++ b/src/tools/customers/lookup-customers.ts
@@ -13,13 +13,13 @@ export class LookupCustomersTool extends BaseTool<LookupCustomersParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
       'pb_customer_lookup',
-      'Search for customers (users and companies) by name. Substring matches against both user names and company names. For each matched company, also lists users belonging to it.',
+      'Search for customers (users and companies) by name. Use this to check whether a person or company already exists in Productboard before creating a note or new customer. The API does literal substring matching against user and company names — it does not normalize spaces, casing variations, or punctuation. If results look incomplete or wrong, try alternate phrasings (a shorter or more distinctive substring, removing spaces, dropping punctuation) before concluding the customer is missing. For each matched company, also lists users belonging to it.',
       {
         type: 'object',
         properties: {
           query: {
             type: 'string',
-            description: 'Search string. Matches as a substring against user names and company names.',
+            description: 'Search string. Matches as a literal substring against user and company names — case-insensitive but exact on whitespace and punctuation. "empty kitchen" will match "Empty Kitchens, Full Hearts" but not "Emptykitchens.co"; "empty" will match both.',
           },
           archived: {
             type: 'boolean',

--- a/src/tools/customers/lookup-customers.ts
+++ b/src/tools/customers/lookup-customers.ts
@@ -1,0 +1,133 @@
+import { BaseTool } from '../base.js';
+import { ProductboardAPIClient } from '@api/index.js';
+import { Logger } from '@utils/logger.js';
+import { Permission, AccessLevel } from '@auth/permissions.js';
+
+interface LookupCustomersParams {
+  query: string;
+  archived?: boolean;
+  limit?: number;
+}
+
+export class LookupCustomersTool extends BaseTool<LookupCustomersParams> {
+  constructor(apiClient: ProductboardAPIClient, logger: Logger) {
+    super(
+      'pb_customer_lookup',
+      'Search for customers (users and companies) by name. Substring matches against both user names and company names. For each matched company, also lists users belonging to it.',
+      {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Search string. Matches as a substring against user names and company names.',
+          },
+          archived: {
+            type: 'boolean',
+            default: false,
+            description: 'Include archived customers (default false)',
+          },
+          limit: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 500,
+            default: 50,
+            description: 'Maximum number of search results (companies + users) to return',
+          },
+        },
+        required: ['query'],
+      },
+      {
+        requiredPermissions: [Permission.NOTES_READ],
+        minimumAccessLevel: AccessLevel.READ,
+        description: 'Requires read access to customer data',
+      },
+      apiClient,
+      logger
+    );
+  }
+
+  protected async executeInternal(params: LookupCustomersParams): Promise<unknown> {
+    const archived = params.archived ?? false;
+    const queryParams: Record<string, any> = {
+      'type[]': ['user', 'company'],
+      name: params.query,
+      archived,
+    };
+
+    const allResults = await this.apiClient.getAllPages<any>('/entities', queryParams);
+    const limit = params.limit ?? 50;
+    const results = allResults.slice(0, limit);
+
+    const users = results.filter((e: any) => e.type === 'user');
+    const companies = results.filter((e: any) => e.type === 'company');
+
+    // For each matched company, fetch users that belong to it (parent[id])
+    const usersByCompany = new Map<string, any[]>();
+    await Promise.all(
+      companies.map(async (c: any) => {
+        const companyUsers = await this.apiClient.getAllPages<any>('/entities', {
+          'type[]': 'user',
+          'parent[id]': c.id,
+          archived,
+        });
+        usersByCompany.set(c.id, companyUsers);
+      })
+    );
+
+    // Build company id -> name map for users with parent company (used in fallback display)
+    const companyById = new Map<string, string>();
+    for (const c of companies) {
+      companyById.set(c.id, c.fields?.name ?? '');
+    }
+
+    if (allResults.length === 0) {
+      return {
+        content: [{ type: 'text', text: `No customers found matching "${params.query}".` }],
+      };
+    }
+
+    const lines: string[] = [
+      `Found ${allResults.length} customer${allResults.length === 1 ? '' : 's'} matching "${params.query}", showing ${results.length}:`,
+      '',
+    ];
+
+    if (companies.length > 0) {
+      lines.push(`Companies (${companies.length}):`);
+      companies.forEach((c, i) => {
+        lines.push(`  ${i + 1}. ${c.fields?.name ?? ''}`);
+        lines.push(`     ID: ${c.id}`);
+        if (c.fields?.domain) lines.push(`     Domain: ${c.fields.domain}`);
+        const companyUsers = usersByCompany.get(c.id) ?? [];
+        if (companyUsers.length > 0) {
+          lines.push(`     Users (${companyUsers.length}):`);
+          companyUsers.forEach((u: any) => {
+            const name = u.fields?.name ?? '';
+            const email = u.fields?.email ?? '';
+            lines.push(`       - ${name}${email ? `  (${email})` : ''}`);
+          });
+        } else {
+          lines.push(`     Users: none`);
+        }
+      });
+      lines.push('');
+    }
+
+    if (users.length > 0) {
+      lines.push(`Users matching "${params.query}" (${users.length}):`);
+      users.forEach((u, i) => {
+        const name = u.fields?.name ?? '';
+        const email = u.fields?.email ?? '';
+        const parentCompanyId = u.relationships?.parent?.id;
+        const parentCompanyName = parentCompanyId ? companyById.get(parentCompanyId) : undefined;
+        lines.push(`  ${i + 1}. ${name}`);
+        lines.push(`     ID: ${u.id}`);
+        if (email) lines.push(`     Email: ${email}`);
+        if (parentCompanyName) lines.push(`     Company: ${parentCompanyName}`);
+      });
+    }
+
+    return {
+      content: [{ type: 'text', text: lines.join('\n') }],
+    };
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,3 +12,6 @@ export * from './objectives/index.js';
 
 // Release Management tools
 export * from './releases/index.js';
+
+// Customer tools
+export * from './customers/index.js';

--- a/tests/unit/tools/customers/lookup-customers.test.ts
+++ b/tests/unit/tools/customers/lookup-customers.test.ts
@@ -1,0 +1,164 @@
+import { LookupCustomersTool } from '@tools/customers/lookup-customers';
+import { ProductboardAPIClient } from '@api/index';
+import { Logger } from '@utils/logger';
+
+describe('LookupCustomersTool', () => {
+  let tool: LookupCustomersTool;
+  let mockApiClient: jest.Mocked<ProductboardAPIClient>;
+  let mockLogger: jest.Mocked<Logger>;
+
+  beforeEach(() => {
+    mockApiClient = {
+      makeRequest: jest.fn(),
+      getAllPages: jest.fn(),
+    } as any;
+
+    mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+    } as any;
+
+    tool = new LookupCustomersTool(mockApiClient, mockLogger);
+  });
+
+  describe('constructor', () => {
+    it('should initialize with correct name and description', () => {
+      expect(tool.name).toBe('pb_customer_lookup');
+      expect(tool.description).toContain('users and companies');
+    });
+
+    it('should require query param', () => {
+      expect(tool.parameters).toMatchObject({
+        type: 'object',
+        required: ['query'],
+      });
+    });
+  });
+
+  describe('execute', () => {
+    it('passes query, type[]=user+company, and archived=false by default', async () => {
+      mockApiClient.getAllPages.mockResolvedValueOnce([]);
+
+      await tool.execute({ query: 'wright' });
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': ['user', 'company'],
+        name: 'wright',
+        archived: false,
+      });
+    });
+
+    it('passes archived=true when explicitly requested', async () => {
+      mockApiClient.getAllPages.mockResolvedValueOnce([]);
+
+      await tool.execute({ query: 'wright', archived: true });
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': ['user', 'company'],
+        name: 'wright',
+        archived: true,
+      });
+    });
+
+    it('returns "no customers found" when results are empty', async () => {
+      mockApiClient.getAllPages.mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({ query: 'nobody' });
+
+      expect(result.content[0].text).toContain('No customers found');
+      expect(result.content[0].text).toContain('nobody');
+    });
+
+    it('groups results into companies and users', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([
+          { id: 'c1', type: 'company', fields: { name: 'Wright Tank Services', domain: 'wrighttank.com' } },
+          { id: 'u1', type: 'user', fields: { name: 'Ethan Wright', email: 'ethan@wright.com' } },
+        ])
+        .mockResolvedValueOnce([]); // users under c1
+
+      const result: any = await tool.execute({ query: 'wright' });
+      const text = result.content[0].text;
+
+      expect(text).toContain('Companies (1):');
+      expect(text).toContain('Wright Tank Services');
+      expect(text).toContain('wrighttank.com');
+      expect(text).toContain('Users matching "wright" (1):');
+      expect(text).toContain('Ethan Wright');
+      expect(text).toContain('ethan@wright.com');
+    });
+
+    it('lists users belonging to each matched company', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([
+          { id: 'c1', type: 'company', fields: { name: 'Empty Kitchens, Full Hearts' } },
+        ])
+        .mockResolvedValueOnce([
+          { id: 'u1', type: 'user', fields: { name: 'Andrew', email: 'andrew@ekfh.org' } },
+          { id: 'u2', type: 'user', fields: { name: 'Bea', email: '' } },
+        ]);
+
+      const result: any = await tool.execute({ query: 'empty' });
+      const text = result.content[0].text;
+
+      expect(text).toContain('Empty Kitchens, Full Hearts');
+      expect(text).toContain('Users (2):');
+      expect(text).toContain('Andrew');
+      expect(text).toContain('andrew@ekfh.org');
+      expect(text).toContain('Bea');
+    });
+
+    it('shows "Users: none" when a matched company has no users', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([
+          { id: 'c1', type: 'company', fields: { name: 'Acme' } },
+        ])
+        .mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({ query: 'acme' });
+      expect(result.content[0].text).toContain('Users: none');
+    });
+
+    it('fetches users per matched company with parent[id] filter', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([
+          { id: 'c1', type: 'company', fields: { name: 'Co1' } },
+          { id: 'c2', type: 'company', fields: { name: 'Co2' } },
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      await tool.execute({ query: 'co' });
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'user',
+        'parent[id]': 'c1',
+        archived: false,
+      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'user',
+        'parent[id]': 'c2',
+        archived: false,
+      });
+    });
+
+    it('respects limit on initial search results', async () => {
+      const many = Array.from({ length: 5 }, (_, i) => ({
+        id: `u${i}`,
+        type: 'user',
+        fields: { name: `User ${i}` },
+      }));
+      mockApiClient.getAllPages.mockResolvedValueOnce(many);
+
+      const result: any = await tool.execute({ query: 'user', limit: 2 });
+      const text = result.content[0].text;
+
+      expect(text).toContain('Found 5 customers matching "user", showing 2');
+      expect(text).toContain('User 0');
+      expect(text).toContain('User 1');
+      expect(text).not.toContain('User 2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Looking up whether a specific customer (user or company) exists in Productboard required dumping notes and searching through them, or guessing the right `customer_email` for `pb_note_create`. Neither tells you reliably whether a customer is already in the workspace before you try to create one.

The new `pb_customer_lookup` tool answers the question directly: pass a search string, get back matching users and companies, and for each matched company, the users belonging to it.

## Changes

- Added `pb_customer_lookup` tool in `src/tools/customers/`
- Searches both `user` and `company` entities in a single API call (`type[]=user&type[]=company&name=...`)
- Defaults to excluding archived customers
- For each matched company, fetches users via `parent[id]` filter and lists them inline
- Tool description tells Claude the API does literal substring matching (case-insensitive but exact on whitespace/punctuation), so it tries alternate phrasings when results look incomplete

## Test plan

- [ ] Run `npm test` — all 298 tests pass
- [ ] Ask "do I have a customer for X?" with various phrasings — verify both companies and users with that name show up, and users under each company appear nested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>