### PR TITLE
Add pb_note_update to link notes to features and mark them processed

### DIFF
--- a/src/tools/notes/index.ts
+++ b/src/tools/notes/index.ts
@@ -1,2 +1,3 @@
 export { CreateNoteTool } from './create-note.js';
 export { ListNotesTool } from './list-notes.js';
+export { UpdateNoteTool } from './update-note.js';

--- a/src/tools/notes/list-notes.ts
+++ b/src/tools/notes/list-notes.ts
@@ -144,6 +144,7 @@ export class ListNotesTool extends BaseTool<ListNotesParams> {
       ? `Found ${allNotes.length} notes total, showing ${formattedNotes.length}:\n\n` +
         formattedNotes.map((n, i) =>
           `${i + 1}. ${n.title}\n` +
+          `   ID: ${n.id}\n` +
           `   Owner: ${n.owner}\n` +
           `   Content: ${n.content}\n` +
           `   Tags: ${n.tags.length > 0 ? n.tags.join(', ') : 'None'}\n`

--- a/src/tools/notes/update-note.ts
+++ b/src/tools/notes/update-note.ts
@@ -1,0 +1,171 @@
+import { BaseTool } from '../base.js';
+import { ProductboardAPIClient } from '@api/index.js';
+import { Logger } from '@utils/logger.js';
+import { Permission, AccessLevel } from '@auth/permissions.js';
+
+interface UpdateNoteParams {
+  id: string;
+  processed?: boolean;
+  archived?: boolean;
+  name?: string;
+  owner_email?: string;
+  owner_id?: string;
+  link_feature_ids?: string[];
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class UpdateNoteTool extends BaseTool<UpdateNoteParams> {
+  constructor(apiClient: ProductboardAPIClient, logger: Logger) {
+    super(
+      'pb_note_update',
+      'Update an existing note: link it to features and/or mark it processed. Use this once you\'ve extracted insights from a note and identified which features it relates to.',
+      {
+        type: 'object',
+        required: ['id'],
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Note UUID',
+          },
+          processed: {
+            type: 'boolean',
+            description: 'Set the note\'s processed flag (true to mark processed, false to mark unprocessed).',
+          },
+          archived: {
+            type: 'boolean',
+            description: 'Set the note\'s archived flag.',
+          },
+          name: {
+            type: 'string',
+            description: 'New title for the note.',
+          },
+          owner_email: {
+            type: 'string',
+            description: 'Reassign the note to an owner by email.',
+          },
+          owner_id: {
+            type: 'string',
+            description: 'Reassign the note to an owner by user UUID.',
+          },
+          link_feature_ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'List of feature UUIDs to link to this note. Each one is added (existing links are not removed). The Productboard v2 API does not expose an endpoint to remove note relationships.',
+          },
+        },
+      },
+      {
+        requiredPermissions: [Permission.NOTES_WRITE],
+        minimumAccessLevel: AccessLevel.WRITE,
+        description: 'Requires write access to notes',
+      },
+      apiClient,
+      logger
+    );
+  }
+
+  protected async executeInternal(params: UpdateNoteParams): Promise<unknown> {
+    if (!UUID_RE.test(params.id)) {
+      return {
+        success: false,
+        error: `"${params.id}" is not a valid note UUID.`,
+      };
+    }
+
+    const fields: Record<string, unknown> = {};
+    if (params.processed !== undefined) fields.processed = params.processed;
+    if (params.archived !== undefined) fields.archived = params.archived;
+    if (params.name !== undefined) fields.name = params.name;
+    if (params.owner_email !== undefined) fields.owner = { email: params.owner_email };
+    if (params.owner_id !== undefined) fields.owner = { id: params.owner_id };
+
+    const linkIds = params.link_feature_ids ?? [];
+
+    if (Object.keys(fields).length === 0 && linkIds.length === 0) {
+      return {
+        success: false,
+        error: 'Nothing to update. Provide at least one of: processed, archived, name, owner_email, owner_id, link_feature_ids.',
+      };
+    }
+
+    const summary: string[] = [];
+
+    // 1. POST a relationship per feature link first. If any link fails, we
+    //    skip the field update so the note isn't marked processed for an
+    //    incomplete linking. The v2 API doesn't support bulk add, so we
+    //    issue one request per ID.
+    const linked: string[] = [];
+    const linkFailures: { id: string; error: string }[] = [];
+    for (const featureId of linkIds) {
+      if (!UUID_RE.test(featureId)) {
+        linkFailures.push({ id: featureId, error: 'not a valid UUID' });
+        continue;
+      }
+      try {
+        await this.apiClient.post(`/notes/${params.id}/relationships`, {
+          data: { type: 'link', target: { id: featureId, type: 'link' } },
+        });
+        linked.push(featureId);
+      } catch (err) {
+        linkFailures.push({
+          id: featureId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    if (linked.length > 0) {
+      summary.push(`Linked ${linked.length} feature${linked.length === 1 ? '' : 's'}: ${linked.join(', ')}`);
+    }
+    if (linkFailures.length > 0) {
+      summary.push(
+        `Failed to link ${linkFailures.length}: ${linkFailures
+          .map((f) => `${f.id} (${f.error})`)
+          .join('; ')}`
+      );
+    }
+
+    // 2. PATCH fields only if all linking succeeded. If any link failed and
+    //    fields were also requested, skip the PATCH so processed=true isn't
+    //    set on a note whose feature linking was incomplete.
+    let fieldsApplied = false;
+    if (Object.keys(fields).length > 0) {
+      if (linkFailures.length > 0) {
+        summary.push(
+          `Skipped field update (${Object.keys(fields).join(', ')}) because feature linking failed.`
+        );
+      } else {
+        try {
+          await this.apiClient.patch(`/notes/${params.id}`, {
+            data: { type: 'textNote', fields },
+          });
+          fieldsApplied = true;
+          const changed = Object.entries(fields).map(([k, v]) => `${k}=${v}`).join(', ');
+          summary.push(`Updated fields: ${changed}`);
+        } catch (err) {
+          return {
+            success: false,
+            error: `Failed to update note fields: ${err instanceof Error ? err.message : String(err)}`,
+            data: {
+              id: params.id,
+              linkedFeatureIds: linked,
+              failedLinks: linkFailures,
+            },
+          };
+        }
+      }
+    }
+
+    return {
+      success: linkFailures.length === 0,
+      data: {
+        id: params.id,
+        updatedFields: fieldsApplied ? fields : {},
+        linkedFeatureIds: linked,
+        failedLinks: linkFailures,
+      },
+      summary: summary.join('\n'),
+    };
+  }
+}

--- a/tests/unit/tools/notes/update-note.test.ts
+++ b/tests/unit/tools/notes/update-note.test.ts
@@ -1,0 +1,209 @@
+import { UpdateNoteTool } from '@tools/notes/update-note';
+import { ProductboardAPIClient } from '@api/index';
+import { Logger } from '@utils/logger';
+
+describe('UpdateNoteTool', () => {
+  let tool: UpdateNoteTool;
+  let mockApiClient: jest.Mocked<ProductboardAPIClient>;
+  let mockLogger: jest.Mocked<Logger>;
+
+  const NOTE_ID = 'd5cdda81-f0d6-44c9-8a4f-4924f22ec678';
+  const FEATURE_ID = 'ea5e764a-bcf0-4ae2-abaa-baba0f5a3e8c';
+
+  beforeEach(() => {
+    mockApiClient = {
+      get: jest.fn(),
+      post: jest.fn().mockResolvedValue({ data: {} }),
+      patch: jest.fn().mockResolvedValue({ data: {} }),
+      put: jest.fn(),
+      delete: jest.fn(),
+      makeRequest: jest.fn(),
+      getAllPages: jest.fn(),
+    } as any;
+
+    mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+    } as any;
+
+    tool = new UpdateNoteTool(mockApiClient, mockLogger);
+  });
+
+  describe('constructor', () => {
+    it('has correct name and description', () => {
+      expect(tool.name).toBe('pb_note_update');
+      expect(tool.description).toContain('Update an existing note');
+    });
+
+    it('requires id', () => {
+      expect(tool.parameters).toMatchObject({ required: ['id'] });
+    });
+  });
+
+  const parse = (result: any) => JSON.parse(result.content[0].text);
+
+  describe('execute', () => {
+    it('rejects invalid note UUID', async () => {
+      const result = await tool.execute({ id: 'not-a-uuid', processed: true });
+      const parsed = parse(result);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('not a valid note UUID');
+    });
+
+    it('rejects when nothing to update', async () => {
+      const result = await tool.execute({ id: NOTE_ID });
+      const parsed = parse(result);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('Nothing to update');
+    });
+
+    it('PATCHes fields when processed is provided', async () => {
+      await tool.execute({ id: NOTE_ID, processed: true });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(`/notes/${NOTE_ID}`, {
+        data: { type: 'textNote', fields: { processed: true } },
+      });
+    });
+
+    it('PATCHes processed=false to mark a note unprocessed', async () => {
+      await tool.execute({ id: NOTE_ID, processed: false });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(`/notes/${NOTE_ID}`, {
+        data: { type: 'textNote', fields: { processed: false } },
+      });
+    });
+
+    it('PATCHes archived and name together', async () => {
+      await tool.execute({ id: NOTE_ID, archived: true, name: 'New title' });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(`/notes/${NOTE_ID}`, {
+        data: { type: 'textNote', fields: { archived: true, name: 'New title' } },
+      });
+    });
+
+    it('PATCHes owner by email', async () => {
+      await tool.execute({ id: NOTE_ID, owner_email: 'sophie@routific.com' });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(`/notes/${NOTE_ID}`, {
+        data: { type: 'textNote', fields: { owner: { email: 'sophie@routific.com' } } },
+      });
+    });
+
+    it('PATCHes owner by id', async () => {
+      await tool.execute({ id: NOTE_ID, owner_id: '4f19d484-13e7-4ffd-a0cb-b4e9505cba1f' });
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(`/notes/${NOTE_ID}`, {
+        data: { type: 'textNote', fields: { owner: { id: '4f19d484-13e7-4ffd-a0cb-b4e9505cba1f' } } },
+      });
+    });
+
+    it('POSTs one relationship per feature link', async () => {
+      const FID2 = 'd62512d0-450b-43b8-b647-4388002995ae';
+      const result = await tool.execute({
+        id: NOTE_ID,
+        link_feature_ids: [FEATURE_ID, FID2],
+      });
+      const parsed = parse(result);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        `/notes/${NOTE_ID}/relationships`,
+        { data: { type: 'link', target: { id: FEATURE_ID, type: 'link' } } }
+      );
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        `/notes/${NOTE_ID}/relationships`,
+        { data: { type: 'link', target: { id: FID2, type: 'link' } } }
+      );
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.linkedFeatureIds).toEqual([FEATURE_ID, FID2]);
+    });
+
+    it('does both PATCH and POST in one call when both are requested, linking first', async () => {
+      const callOrder: string[] = [];
+      mockApiClient.post.mockImplementation(async () => {
+        callOrder.push('post');
+        return { data: {} } as any;
+      });
+      mockApiClient.patch.mockImplementation(async () => {
+        callOrder.push('patch');
+        return { data: {} } as any;
+      });
+
+      await tool.execute({
+        id: NOTE_ID,
+        processed: true,
+        link_feature_ids: [FEATURE_ID],
+      });
+
+      expect(mockApiClient.patch).toHaveBeenCalledTimes(1);
+      expect(mockApiClient.post).toHaveBeenCalledTimes(1);
+      expect(callOrder).toEqual(['post', 'patch']);
+    });
+
+    it('skips PATCH when any feature link fails', async () => {
+      mockApiClient.post.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await tool.execute({
+        id: NOTE_ID,
+        processed: true,
+        link_feature_ids: [FEATURE_ID],
+      });
+      const parsed = parse(result);
+
+      expect(mockApiClient.post).toHaveBeenCalledTimes(1);
+      expect(mockApiClient.patch).not.toHaveBeenCalled();
+      expect(parsed.success).toBe(false);
+      expect(parsed.data.linkedFeatureIds).toEqual([]);
+      expect(parsed.data.failedLinks).toEqual([{ id: FEATURE_ID, error: 'boom' }]);
+      // processed should NOT be in updatedFields
+      expect(parsed.data.updatedFields).toEqual({});
+    });
+
+    it('skips PATCH when an invalid feature UUID is rejected client-side', async () => {
+      const result = await tool.execute({
+        id: NOTE_ID,
+        processed: true,
+        link_feature_ids: ['not-a-uuid'],
+      });
+      const parsed = parse(result);
+
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+      expect(mockApiClient.patch).not.toHaveBeenCalled();
+      expect(parsed.success).toBe(false);
+      expect(parsed.data.updatedFields).toEqual({});
+    });
+
+    it('reports invalid feature UUID without making the API call', async () => {
+      const result = await tool.execute({
+        id: NOTE_ID,
+        link_feature_ids: ['nope', FEATURE_ID],
+      });
+      const parsed = parse(result);
+
+      // Only the valid one should hit the API
+      expect(mockApiClient.post).toHaveBeenCalledTimes(1);
+      expect(parsed.data.linkedFeatureIds).toEqual([FEATURE_ID]);
+      expect(parsed.data.failedLinks).toEqual([{ id: 'nope', error: 'not a valid UUID' }]);
+      expect(parsed.success).toBe(false);
+    });
+
+    it('continues linking remaining features when one fails', async () => {
+      const FID2 = 'd62512d0-450b-43b8-b647-4388002995ae';
+      mockApiClient.post
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ data: {} });
+
+      const result = await tool.execute({
+        id: NOTE_ID,
+        link_feature_ids: [FEATURE_ID, FID2],
+      });
+      const parsed = parse(result);
+
+      expect(mockApiClient.post).toHaveBeenCalledTimes(2);
+      expect(parsed.data.linkedFeatureIds).toEqual([FID2]);
+      expect(parsed.data.failedLinks).toEqual([{ id: FEATURE_ID, error: 'boom' }]);
+      expect(parsed.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Unprocessed notes need to be manually linked to features and marked processed. `pb_note_update` lets you link a note to one or more features, then mark it processed. If linking fails for any reason, the note isn't marked processed so it still shows as work to do. Other note update capabilities added to match the v2 API.

## Test plan
- [ ] Run `npm test` — all 303 tests pass
- [ ] Pick an unprocessed note, call `pb_note_update` with `link_feature_ids` and `processed: true` — verify both happened in the UI
- [ ] Call with a bogus feature ID + `processed: true` — verify the note stays unprocessed and the failure is reported
- [ ] Confirm `pb_note_list` now shows note IDs so you can find UUIDs to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>