### PR TITLE
Add feature health/source tools, Jira read tools, Windows packaging f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ pids/
 # Output of 'npm pack'
 *.tgz
 
+# Output of 'mcpb pack' — versioned MCP bundles
+*.mcpb
+
 # Yarn Integrity file
 .yarn-integrity
 

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,45 @@
+# Source — runtime ships compiled dist/ only
+src/
+tests/
+scripts/
+
+# Build artifacts not needed at runtime
+dist/**/*.map
+dist/**/*.d.ts
+dist/**/*.d.ts.map
+
+# Repo dev files
+.github/
+.claude/
+.vscode/
+.idea/
+coverage/
+.husky/
+
+# Backups / patches / scratch
+*.backup
+*.bak
+*.patch
+*.orig
+*.swp
+*.swo
+*.log
+
+# Configs not needed at runtime
+.eslintrc*
+.prettierrc*
+.editorconfig
+.gitignore
+.gitattributes
+.npmignore
+.dockerignore
+jest.config.*
+tsconfig.json
+tsconfig.*.json
+smithery.yaml
+.env
+.env.*
+
+# Other packaged outputs
+*.mcpb
+*.tgz

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1",
   "name": "productboard-mcp",
   "display_name": "Productboard",
-  "version": "0.3.0",
+  "version": "0.7.0",
   "description": "MCP server for the Productboard API. Enables AI assistants (Claude, Cursor, etc.) to interact with your Productboard workspace.",
   "author": {
     "name": "Enreign",
@@ -32,6 +32,8 @@
     { "name": "pb_feature_get", "description": "Get a feature by ID" },
     { "name": "pb_feature_create", "description": "Create a new feature" },
     { "name": "pb_feature_update", "description": "Update an existing feature" },
+    { "name": "pb_feature_health_update", "description": "Update a feature's health status, comment, and mode" },
+    { "name": "pb_feature_source_set", "description": "Set external-source provenance metadata (system, recordId, url) on a feature — works for Jira, Salesforce, Intercom, etc. NOT a functional Jira integration connection." },
     { "name": "pb_feature_delete", "description": "Delete a feature" },
     { "name": "pb_product_list", "description": "List products" },
     { "name": "pb_product_create", "description": "Create a product" },
@@ -48,7 +50,9 @@
     { "name": "pb_release_create", "description": "Create a release" },
     { "name": "pb_release_update", "description": "Update a release" },
     { "name": "pb_release_status_update", "description": "Update release status" },
-    { "name": "pb_release_timeline", "description": "Get release timeline" }
+    { "name": "pb_release_timeline", "description": "Get release timeline" },
+    { "name": "pb_jira_integration_list", "description": "List Jira integrations configured in the workspace" },
+    { "name": "pb_jira_connection_list", "description": "List feature ↔ Jira issue connections for an integration (read-only — Productboard's API does not expose create/delete)" }
   ],
   "keywords": ["productboard", "mcp", "product-management"],
   "compatibility": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@enreign/productboard-mcp",
-  "version": "0.3.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@enreign/productboard-mcp",
-      "version": "0.3.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enreign/productboard-mcp",
-  "version": "0.3.0",
+  "version": "0.7.0",
   "description": "MCP server for Productboard API integration",
   "main": "dist/index.js",
   "bin": "./productboard-mcp.js",
@@ -17,6 +17,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc && node scripts/fix-imports.js && chmod +x dist/index.js",
+    "build:clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && npm run build",
+    "pack:mcpb": "npm run build:clean && npm prune --omit=dev && node scripts/pack-mcpb.js && npm install",
     "prepublishOnly": "npm run build",
     "dev": "tsx --watch src/index.ts",
     "start": "node dist/index.js",

--- a/scripts/fix-imports.js
+++ b/scripts/fix-imports.js
@@ -24,7 +24,10 @@ const aliasToDir = {
 function getRelativePath(fromFile, toDir) {
   const fromDir = dirname(fromFile);
   const toPath = join(distDir, toDir);
-  const relativePath = relative(fromDir, toPath);
+  // Always use forward slashes in ESM import specifiers — on Windows,
+  // path.relative returns backslashes, which the JS parser then reads
+  // as escape sequences (e.g. "..\utils" → invalid \u escape).
+  const relativePath = relative(fromDir, toPath).split('\\').join('/');
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
 }
 

--- a/scripts/pack-mcpb.js
+++ b/scripts/pack-mcpb.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Pack the project into a versioned .mcpb file: <name>-<version>.mcpb
+// Reads version from manifest.json (the source of truth for the bundle).
+
+import { spawnSync } from 'child_process';
+import { readFileSync, existsSync, unlinkSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, '..');
+
+const manifest = JSON.parse(readFileSync(join(projectRoot, 'manifest.json'), 'utf8'));
+const { name, version } = manifest;
+if (!name || !version) {
+  console.error('manifest.json must contain "name" and "version"');
+  process.exit(1);
+}
+
+const outputFile = `${name}-${version}.mcpb`;
+const outputPath = join(projectRoot, outputFile);
+
+// Remove a stale artifact with the same name so mcpb doesn't include it.
+if (existsSync(outputPath)) unlinkSync(outputPath);
+
+// Also remove the legacy unversioned file if it exists, so consumers don't
+// accidentally install an old build.
+const legacy = join(projectRoot, `${name}.mcpb`);
+if (existsSync(legacy)) unlinkSync(legacy);
+
+const result = spawnSync('mcpb', ['pack', '.', outputFile], {
+  cwd: projectRoot,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+if (result.status !== 0) {
+  console.error(`mcpb pack failed with status ${result.status}`);
+  process.exit(result.status ?? 1);
+}
+
+console.log(`\nPacked: ${outputFile}`);

--- a/src/tools/features/index.ts
+++ b/src/tools/features/index.ts
@@ -1,5 +1,7 @@
 export { CreateFeatureTool } from './create-feature.js';
 export { ListFeaturesTool } from './list-features.js';
 export { UpdateFeatureTool } from './update-feature.js';
+export { UpdateFeatureHealthTool } from './update-feature-health.js';
+export { SetFeatureSourceTool } from './set-feature-source.js';
 export { DeleteFeatureTool } from './delete-feature.js';
 export { GetFeatureTool } from './get-feature.js';

--- a/src/tools/features/set-feature-source.ts
+++ b/src/tools/features/set-feature-source.ts
@@ -1,0 +1,119 @@
+import { BaseTool } from '../base.js';
+import { ProductboardAPIClient } from '@api/client.js';
+import { Logger } from '@utils/logger.js';
+import { Permission, AccessLevel } from '@auth/permissions.js';
+
+interface SetFeatureSourceParams {
+  id: string;
+  system?: string;
+  record_id?: string;
+  url?: string;
+}
+
+/**
+ * Sets feature.metadata.source.{system, recordId, url} via PATCH /entities/{id}.
+ *
+ * This is provenance metadata — it stores a cross-reference to a record in an
+ * external system (Jira, Salesforce, Intercom, etc.) on the feature. It does
+ * NOT create a functional integration connection: there is no status sync,
+ * the link does not appear in the Productboard Jira sidebar UI, and the entry
+ * is not returned by pb_jira_connection_list. For a real Jira connection,
+ * create it through the Productboard UI or via the Jira-side integration.
+ *
+ * Partial updates are supported: only the fields you pass are changed; the
+ * others are preserved (read-modify-write).
+ */
+export class SetFeatureSourceTool extends BaseTool<SetFeatureSourceParams> {
+  constructor(apiClient: ProductboardAPIClient, logger: Logger) {
+    super(
+      'pb_feature_source_set',
+      'Set the external-source provenance metadata (metadata.source) on a feature: which external system it relates to, the record ID in that system, and a URL. Generic — works for Jira, Salesforce, Intercom, etc. NOTE: this is metadata only; it does NOT create a functional Jira integration connection (no status sync, no Productboard Jira sidebar link). Pass empty string "" to clear an individual field; omit a field to leave it unchanged.',
+      {
+        type: 'object',
+        required: ['id'],
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Feature UUID',
+          },
+          system: {
+            type: 'string',
+            description: 'External system name (e.g. "Jira", "Salesforce", "Intercom"). Pass empty string "" to clear.',
+          },
+          record_id: {
+            type: 'string',
+            description: 'Record identifier in that system (e.g. "INT-3775" for a Jira issue). Pass empty string "" to clear.',
+          },
+          url: {
+            type: 'string',
+            description: 'URL to the record (e.g. "https://your-org.atlassian.net/browse/INT-3775"). Pass empty string "" to clear.',
+          },
+        },
+      },
+      {
+        requiredPermissions: [Permission.FEATURES_WRITE],
+        minimumAccessLevel: AccessLevel.WRITE,
+        description: 'Requires write access to features',
+      },
+      apiClient,
+      logger
+    );
+  }
+
+  validateParams(params: unknown) {
+    const baseValidation = super.validateParams(params);
+    if (!baseValidation.valid) return baseValidation;
+
+    const p = params as unknown as Record<string, unknown>;
+    const provided = ['system', 'record_id', 'url'].filter((k) => k in p);
+    if (provided.length === 0) {
+      return {
+        valid: false,
+        errors: [{
+          path: '',
+          message: 'At least one of system, record_id, or url must be provided',
+          value: undefined,
+        }],
+      };
+    }
+    return { valid: true, errors: [] };
+  }
+
+  protected async executeInternal(params: SetFeatureSourceParams): Promise<unknown> {
+    const { id } = params;
+
+    // Read-modify-write so partial updates don't clobber unspecified fields.
+    const current = await this.apiClient.get<unknown>(`/entities/${id}`);
+    const existingSource = ((current as any)?.data?.fields?.metadata?.source
+      ?? (current as any)?.data?.metadata?.source
+      ?? {}) as Record<string, unknown>;
+
+    const source: Record<string, unknown> = {
+      system: existingSource.system ?? null,
+      recordId: existingSource.recordId ?? null,
+      url: existingSource.url ?? null,
+    };
+    // Empty string "" → null (explicit clear). Undefined → keep existing value.
+    const raw = params as unknown as Record<string, unknown>;
+    const norm = (v: string | undefined) => (v === '' ? null : v);
+    if ('system' in raw) source.system = norm(params.system);
+    if ('record_id' in raw) source.recordId = norm(params.record_id);
+    if ('url' in raw) source.url = norm(params.url);
+
+    this.logger.info('Setting feature source metadata', {
+      featureId: id,
+      system: source.system,
+      recordId: source.recordId,
+    });
+
+    const response = await this.apiClient.patch(`/entities/${id}`, {
+      data: { metadata: { source } },
+    });
+
+    return {
+      success: true,
+      data: (response as any).data || response,
+      source,
+    };
+  }
+}

--- a/src/tools/features/update-feature-health.ts
+++ b/src/tools/features/update-feature-health.ts
@@ -1,0 +1,91 @@
+import { BaseTool } from '../base.js';
+import { ProductboardAPIClient } from '@api/client.js';
+import { Logger } from '@utils/logger.js';
+import { Permission, AccessLevel } from '@auth/permissions.js';
+
+type HealthStatus = 'onTrack' | 'atRisk' | 'offTrack';
+type HealthMode = 'manual' | 'automatic';
+
+interface UpdateFeatureHealthParams {
+  id: string;
+  status: HealthStatus;
+  comment?: string;
+  mode?: HealthMode;
+}
+
+export class UpdateFeatureHealthTool extends BaseTool<UpdateFeatureHealthParams> {
+  constructor(apiClient: ProductboardAPIClient, logger: Logger) {
+    super(
+      'pb_feature_health_update',
+      'Update the health (status/comment/mode) of an existing feature. Writes the health.status (onTrack | atRisk | offTrack), optional comment (HTML; plain text is wrapped in <p>...</p>), and mode (manual | automatic; default manual). If the feature\'s existing health.mode is "automatic" and the caller does not explicitly pass mode, the update is skipped to avoid being overwritten by Productboard\'s health automation.',
+      {
+        type: 'object',
+        required: ['id', 'status'],
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Feature ID to update',
+          },
+          status: {
+            type: 'string',
+            enum: ['onTrack', 'atRisk', 'offTrack'],
+            description: 'New health status',
+          },
+          comment: {
+            type: 'string',
+            description: 'Optional health comment (HTML or plain text; plain text is auto-wrapped in <p>...</p>)',
+          },
+          mode: {
+            type: 'string',
+            enum: ['manual', 'automatic'],
+            description: 'Health mode. Default is manual. Set to "automatic" to opt into Productboard\'s automated health calculation (which will overwrite the supplied status).',
+          },
+        },
+      },
+      {
+        requiredPermissions: [Permission.FEATURES_WRITE],
+        minimumAccessLevel: AccessLevel.WRITE,
+        description: 'Requires write access to features',
+      },
+      apiClient,
+      logger
+    );
+  }
+
+  protected async executeInternal(params: UpdateFeatureHealthParams): Promise<unknown> {
+    const { id, status, comment, mode } = params;
+
+    // Guard: if existing health.mode is automatic and caller didn't explicitly
+    // pass mode, refuse to write — Productboard's automation will overwrite us.
+    if (mode === undefined) {
+      const current = await this.apiClient.get<unknown>(`/entities/${id}`);
+      const existingMode = (current as any)?.data?.fields?.health?.mode;
+      if (existingMode === 'automatic') {
+        this.logger.warn('Skipping pb_feature_health_update: existing health.mode is automatic', { featureId: id });
+        return {
+          success: false,
+          skipped: true,
+          reason: 'existing_mode_automatic',
+          message: 'Feature health mode is currently "automatic" and would be overwritten by Productboard automation. Pass mode="manual" explicitly to override.',
+        };
+      }
+    }
+
+    const health: Record<string, unknown> = {
+      status,
+      mode: mode ?? 'manual',
+    };
+    if (comment !== undefined) {
+      health.comment = comment.startsWith('<') ? comment : `<p>${comment}</p>`;
+    }
+
+    this.logger.info('Updating feature health', { featureId: id, status, mode: health.mode });
+
+    const response = await this.apiClient.patch(`/entities/${id}`, { data: { fields: { health } } });
+
+    return {
+      success: true,
+      data: (response as any).data || response,
+    };
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,3 +15,6 @@ export * from './releases/index.js';
 
 // Customer tools
 export * from './customers/index.js';
+
+// Jira integration tools
+export * from './jira/index.js';

--- a/src/tools/jira/index.ts
+++ b/src/tools/jira/index.ts
@@ -1,0 +1,2 @@
+export { ListJiraIntegrationsTool } from './list-jira-integrations.js';
+export { ListJiraConnectionsTool } from './list-jira-connections.js';

--- a/src/tools/jira/list-jira-connections.ts
+++ b/src/tools/jira/list-jira-connections.ts
@@ -1,0 +1,66 @@
+import { BaseTool } from '../base.js';
+import { ProductboardAPIClient } from '@api/client.js';
+import { Logger } from '@utils/logger.js';
+import { Permission, AccessLevel } from '@auth/permissions.js';
+
+interface ListJiraConnectionsParams {
+  integration_id: string;
+  jira_issue_key?: string;
+  jira_issue_id?: string;
+}
+
+export class ListJiraConnectionsTool extends BaseTool<ListJiraConnectionsParams> {
+  constructor(apiClient: ProductboardAPIClient, logger: Logger) {
+    super(
+      'pb_jira_connection_list',
+      'List Productboard feature ↔ Jira issue connections for a given integration. Optionally filter by Jira issue key (e.g. INT-4290) or Jira issue ID. Use pb_jira_integration_list first to find the integration_id.',
+      {
+        type: 'object',
+        required: ['integration_id'],
+        properties: {
+          integration_id: {
+            type: 'string',
+            description: 'Jira integration ID (from pb_jira_integration_list)',
+          },
+          jira_issue_key: {
+            type: 'string',
+            description: 'Optional: filter by Jira issue key (e.g. "INT-4290")',
+          },
+          jira_issue_id: {
+            type: 'string',
+            description: 'Optional: filter by Jira numeric issue ID',
+          },
+        },
+      },
+      {
+        requiredPermissions: [Permission.FEATURES_READ],
+        minimumAccessLevel: AccessLevel.READ,
+        description: 'Requires read access to features',
+      },
+      apiClient,
+      logger
+    );
+  }
+
+  protected async executeInternal(params: ListJiraConnectionsParams): Promise<unknown> {
+    this.logger.info('Listing Jira connections', { integrationId: params.integration_id });
+
+    // Productboard v2 API: filter params are bare `issueKey` / `issueId`
+    // (NOT prefixed with `connection.`). The endpoint does not accept
+    // pageLimit/pageOffset query params; pagination is via response links.next.
+    const queryParams: Record<string, any> = {};
+    if (params.jira_issue_key) queryParams.issueKey = params.jira_issue_key;
+    if (params.jira_issue_id) queryParams.issueId = params.jira_issue_id;
+
+    const response = await this.apiClient.get(
+      `/jira-integrations/${encodeURIComponent(params.integration_id)}/connections`,
+      queryParams
+    );
+
+    return {
+      success: true,
+      data: (response as any).data || response,
+      links: (response as any).links,
+    };
+  }
+}

--- a/src/tools/jira/list-jira-integrations.ts
+++ b/src/tools/jira/list-jira-integrations.ts
@@ -1,0 +1,39 @@
+import { BaseTool } from '../base.js';
+import { ProductboardAPIClient } from '@api/client.js';
+import { Logger } from '@utils/logger.js';
+import { Permission, AccessLevel } from '@auth/permissions.js';
+
+interface ListJiraIntegrationsParams {
+  // No parameters — this lists all integrations available to the token
+}
+
+export class ListJiraIntegrationsTool extends BaseTool<ListJiraIntegrationsParams> {
+  constructor(apiClient: ProductboardAPIClient, logger: Logger) {
+    super(
+      'pb_jira_integration_list',
+      'List all Jira integrations configured in the Productboard workspace. Returns integration IDs needed for managing connections between Productboard features and Jira issues.',
+      {
+        type: 'object',
+        properties: {},
+      },
+      {
+        requiredPermissions: [Permission.FEATURES_READ],
+        minimumAccessLevel: AccessLevel.READ,
+        description: 'Requires read access to features (integrations are scoped to feature data)',
+      },
+      apiClient,
+      logger
+    );
+  }
+
+  protected async executeInternal(_params: ListJiraIntegrationsParams): Promise<unknown> {
+    this.logger.info('Listing Jira integrations');
+
+    const response = await this.apiClient.get('/jira-integrations');
+
+    return {
+      success: true,
+      data: (response as any).data || response,
+    };
+  }
+}


### PR DESCRIPTION
…ixes

New tools:
- pb_feature_health_update — set feature.health.{status, comment, mode} via PATCH /entities/{id}. Guards against overwriting Productboard's automatic health mode unless the caller explicitly opts in.
- pb_feature_source_set — set feature.metadata.source.{system, recordId, url} for cross-referencing external systems (Jira, Salesforce, Intercom, etc.). Read-modify-write so partial updates preserve untouched fields. Empty string "" clears an individual field.
- pb_jira_integration_list — GET /jira-integrations.
- pb_jira_connection_list — GET /jira-integrations/{id}/connections. Filter params are bare issueKey / issueId (the prefixed connection.issueKey form returns 400).

Productboard's public API does not expose POST/DELETE for Jira connections (both return route.notFound; the v1 endpoint replies "only GET available"). So this PR is intentionally read-only for that endpoint — speculative create/delete tools have been omitted. Use the Productboard UI or the Jira-side integration for actual sync-enabled connections.

Build / packaging fixes:
- scripts/fix-imports.js: on Windows, path.relative returns backslashes, which Node's ESM parser then interprets as escape sequences (e.g. "..\utils" → invalid \u). Normalize to forward slashes so a clean rebuild on Windows produces a working dist/.
- Add npm run pack:mcpb: clean rebuild → prune devDeps → versioned mcpb pack → restore devDeps. Produces <name>-<version>.mcpb.
- Add scripts/pack-mcpb.js: invokes mcpb pack with the versioned output filename derived from manifest.json, and removes any stale unversioned legacy .mcpb so consumers don't install an old build.
- Add .mcpbignore: keeps tests/, src/, scripts/, build configs, and sourcemaps/decls out of the bundle. Prior bundles were ~22 MB and included devDependencies (jest, eslint, @types/*, typescript, etc.). Pruned + ignored output is ~3.8 MB.
- .gitignore *.mcpb so versioned bundles don't get committed.

manifest.json: version 0.3.0 → 0.7.0, new tool entries added.