### PR TITLE
Make pb_product_hierarchy return the full hierarchy

### DIFF
--- a/src/tools/products/product-hierarchy.ts
+++ b/src/tools/products/product-hierarchy.ts
@@ -8,6 +8,10 @@ interface ProductHierarchyParams {
   include_features?: boolean;
   include_descriptions?: boolean;
   root_id?: string;
+  /** Backwards-compatible alias for root_id used by the previous tool shape. */
+  product_id?: string;
+  /** Maximum child depth to render from the selected root(s). 0 renders only roots. */
+  depth?: number;
 }
 
 type EntityKind = 'product' | 'component' | 'feature' | 'subfeature';
@@ -69,6 +73,15 @@ export class ProductHierarchyTool extends BaseTool<ProductHierarchyParams> {
             type: 'string',
             description: 'Optional UUID of a node to use as the tree root. If omitted, the tree starts from all top-level products.',
           },
+          product_id: {
+            type: 'string',
+            description: 'Deprecated alias for root_id. Preserved for existing callers that pass product_id.',
+          },
+          depth: {
+            type: 'integer',
+            minimum: 0,
+            description: 'Maximum child depth to render from the selected root(s). 0 renders only roots. If omitted, renders the full subtree.',
+          },
         },
       },
       {
@@ -85,6 +98,8 @@ export class ProductHierarchyTool extends BaseTool<ProductHierarchyParams> {
     const archived = params.archived ?? false;
     const includeFeatures = params.include_features ?? true;
     const includeDescriptions = params.include_descriptions ?? false;
+    const rootId = params.root_id ?? params.product_id;
+    const maxDepth = params.depth ?? Number.POSITIVE_INFINITY;
 
     const types: EntityKind[] = includeFeatures
       ? ['product', 'component', 'feature', 'subfeature']
@@ -177,12 +192,12 @@ export class ProductHierarchyTool extends BaseTool<ProductHierarchyParams> {
 
     // Determine roots.
     let roots: Node[];
-    if (params.root_id) {
-      const root = nodeById.get(params.root_id);
+    if (rootId) {
+      const root = nodeById.get(rootId);
       if (!root) {
         return {
           success: false,
-          error: `No entity with id "${params.root_id}" found in the hierarchy.`,
+          error: `No entity with id "${rootId}" found in the hierarchy.`,
         };
       }
       roots = [root];
@@ -209,7 +224,9 @@ export class ProductHierarchyTool extends BaseTool<ProductHierarchyParams> {
       lines.push(
         `${indent}${TYPE_LABEL[node.type]}: ${node.name}${status} (id: ${node.id})${desc}`
       );
-      for (const child of node.children) render(child, depth + 1);
+      if (depth < maxDepth) {
+        for (const child of node.children) render(child, depth + 1);
+      }
     };
 
     for (const root of roots) render(root, 0);
@@ -221,9 +238,7 @@ export class ProductHierarchyTool extends BaseTool<ProductHierarchyParams> {
       );
       orphans.sort((a, b) => a.name.localeCompare(b.name));
       for (const o of orphans) {
-        lines.push(
-          `  ${TYPE_LABEL[o.type]}: ${o.name} (id: ${o.id}, parentId: ${o.parentId ?? 'none'})`
-        );
+        render(o, 1);
       }
     }
 

--- a/src/tools/products/product-hierarchy.ts
+++ b/src/tools/products/product-hierarchy.ts
@@ -102,8 +102,13 @@ export class ProductHierarchyTool extends BaseTool<ProductHierarchyParams> {
 
     const entities: any[] = fetched.flat();
 
-    // Build a node map. The parent of any entity is the relationship with type="parent".
+    // Build a node map. The parent of any entity is the relationship with
+    // type="parent" inside the embedded relationships.data, but that array
+    // is paginated. When an entity has many children listed first, its
+    // parent can fall onto a later page and won't appear here. We collect
+    // those entities and fall back to a targeted relationships fetch below.
     const nodeById = new Map<string, Node>();
+    const needsParentLookup: Node[] = [];
     for (const e of entities) {
       const parentRel = (e.relationships?.data ?? []).find(
         (r: any) => r.type === 'parent'
@@ -122,9 +127,40 @@ export class ProductHierarchyTool extends BaseTool<ProductHierarchyParams> {
         node.status = e.fields.status.name;
       }
       nodeById.set(node.id, node);
+      // Products genuinely have no parent; everything else should.
+      if (!node.parentId && node.type !== 'product') {
+        needsParentLookup.push(node);
+      }
     }
 
-    // Wire children to parents. Entities whose parent isn't in the map are orphans.
+    // Fallback: for every non-product node whose parent wasn't found in
+    // the first page of relationships, hit /entities/{id}/relationships?type=parent
+    // to confirm. This is targeted (only the suspected orphans) and
+    // parallel, so it stays fast even for hundreds of entities.
+    if (needsParentLookup.length > 0) {
+      const lookups = await Promise.all(
+        needsParentLookup.map(async (node) => {
+          try {
+            const res = await this.apiClient.get<any>(
+              `/entities/${node.id}/relationships`,
+              { type: 'parent' }
+            );
+            const items: any[] = (res as any)?.data ?? [];
+            const parentRel = items.find((r: any) => r.type === 'parent');
+            return { node, parentId: parentRel?.target?.id };
+          } catch {
+            return { node, parentId: undefined };
+          }
+        })
+      );
+      for (const { node, parentId } of lookups) {
+        if (parentId) node.parentId = parentId;
+      }
+    }
+
+    // Wire children to parents. Entities whose parent really isn't in the
+    // map after the fallback (deleted parents, parents of a different type
+    // not in our query) end up in the orphans list.
     const orphans: Node[] = [];
     for (const node of nodeById.values()) {
       if (node.parentId && nodeById.has(node.parentId)) {

--- a/src/tools/products/product-hierarchy.ts
+++ b/src/tools/products/product-hierarchy.ts
@@ -2,35 +2,72 @@ import { BaseTool } from '../base.js';
 import { ProductboardAPIClient } from '@api/client.js';
 import { Logger } from '@utils/logger.js';
 import { Permission, AccessLevel } from '@auth/permissions.js';
+
 interface ProductHierarchyParams {
-  product_id?: string;
-  depth?: number;
+  archived?: boolean;
   include_features?: boolean;
+  include_descriptions?: boolean;
+  root_id?: string;
 }
+
+type EntityKind = 'product' | 'component' | 'feature' | 'subfeature';
+
+interface Node {
+  id: string;
+  type: EntityKind;
+  name: string;
+  description?: string;
+  status?: string;
+  parentId?: string;
+  children: Node[];
+}
+
+const TYPE_LABEL: Record<EntityKind, string> = {
+  product: 'Product',
+  component: 'Component',
+  feature: 'Feature',
+  subfeature: 'Subfeature',
+};
+
+const stripHtml = (s: string): string =>
+  s
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const truncate = (s: string, max: number): string =>
+  s.length > max ? s.slice(0, max - 1).trimEnd() + '…' : s;
 
 export class ProductHierarchyTool extends BaseTool<ProductHierarchyParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
       'pb_product_hierarchy',
-      'Get the complete product hierarchy tree',
+      'Get the full Productboard hierarchy (products → components → features → subfeatures) in a single call. Use this to discover where a feature lives in the tree, find candidate features for tagging a note, or understand how the product is organized. The PB API returns only one parent per entity, so this tool fetches every node and builds the tree client-side.',
       {
         type: 'object',
         properties: {
-          product_id: {
-            type: 'string',
-            description: 'Root product ID (optional, defaults to all top-level products)',
-          },
-          depth: {
-            type: 'integer',
-            minimum: 1,
-            maximum: 5,
-            default: 3,
-            description: 'Maximum depth of hierarchy to retrieve',
+          archived: {
+            type: 'boolean',
+            default: false,
+            description: 'Include archived entities (default false). Archived features/components are usually not relevant for tagging new feedback.',
           },
           include_features: {
             type: 'boolean',
+            default: true,
+            description: 'Include features and subfeatures in the tree (default true). Set to false to get just the products/components skeleton, which is much smaller.',
+          },
+          include_descriptions: {
+            type: 'boolean',
             default: false,
-            description: 'Include features at each level',
+            description: 'Include each entity\'s description text (default false). Useful for semantic matching but increases response size significantly.',
+          },
+          root_id: {
+            type: 'string',
+            description: 'Optional UUID of a node to use as the tree root. If omitted, the tree starts from all top-level products.',
           },
         },
       },
@@ -44,26 +81,129 @@ export class ProductHierarchyTool extends BaseTool<ProductHierarchyParams> {
     );
   }
 
-  protected async executeInternal(params: ProductHierarchyParams): Promise<unknown> {
-    this.logger.info('Getting product hierarchy');
+  protected async executeInternal(params: ProductHierarchyParams = {}): Promise<unknown> {
+    const archived = params.archived ?? false;
+    const includeFeatures = params.include_features ?? true;
+    const includeDescriptions = params.include_descriptions ?? false;
 
-    const queryParams: Record<string, any> = { 'type[]': 'product' };
-    if (params.product_id) queryParams.parent_id = params.product_id;
+    const types: EntityKind[] = includeFeatures
+      ? ['product', 'component', 'feature', 'subfeature']
+      : ['product', 'component'];
 
-    const response = await this.apiClient.get('/entities', queryParams);
+    // Fetch all entity types in parallel.
+    const fetched = await Promise.all(
+      types.map((t) =>
+        this.apiClient.getAllPages<any>('/entities', {
+          'type[]': t,
+          archived,
+        })
+      )
+    );
 
-    const products: any[] = Array.isArray((response as any)?.data) ? (response as any).data : [];
+    const entities: any[] = fetched.flat();
 
-    const formatTree = (items: any[], indent = 0): string =>
-      items.map(p =>
-        `${'  '.repeat(indent)}• ${p.fields?.name || 'Untitled'} (ID: ${p.id})\n` +
-        (p.children?.length ? formatTree(p.children, indent + 1) : '')
-      ).join('');
+    // Build a node map. The parent of any entity is the relationship with type="parent".
+    const nodeById = new Map<string, Node>();
+    for (const e of entities) {
+      const parentRel = (e.relationships?.data ?? []).find(
+        (r: any) => r.type === 'parent'
+      );
+      const node: Node = {
+        id: e.id,
+        type: e.type as EntityKind,
+        name: e.fields?.name ?? '(unnamed)',
+        parentId: parentRel?.target?.id,
+        children: [],
+      };
+      if (includeDescriptions && e.fields?.description) {
+        node.description = truncate(stripHtml(e.fields.description), 300);
+      }
+      if (e.fields?.status?.name) {
+        node.status = e.fields.status.name;
+      }
+      nodeById.set(node.id, node);
+    }
 
-    const summary = products.length > 0
-      ? `Product hierarchy (${products.length} products):\n\n` + formatTree(products)
-      : 'No products found.';
+    // Wire children to parents. Entities whose parent isn't in the map are orphans.
+    const orphans: Node[] = [];
+    for (const node of nodeById.values()) {
+      if (node.parentId && nodeById.has(node.parentId)) {
+        nodeById.get(node.parentId)!.children.push(node);
+      } else if (node.type !== 'product') {
+        orphans.push(node);
+      }
+    }
 
-    return { content: [{ type: 'text', text: summary }] };
+    // Sort children by name within each parent for stable output.
+    for (const node of nodeById.values()) {
+      node.children.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    // Determine roots.
+    let roots: Node[];
+    if (params.root_id) {
+      const root = nodeById.get(params.root_id);
+      if (!root) {
+        return {
+          success: false,
+          error: `No entity with id "${params.root_id}" found in the hierarchy.`,
+        };
+      }
+      roots = [root];
+    } else {
+      roots = [...nodeById.values()]
+        .filter((n) => n.type === 'product')
+        .sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    // Build text output. Compact lines, indentation = depth.
+    const lines: string[] = [];
+    const counts: Record<EntityKind, number> = {
+      product: 0,
+      component: 0,
+      feature: 0,
+      subfeature: 0,
+    };
+
+    const render = (node: Node, depth: number): void => {
+      counts[node.type]++;
+      const indent = '  '.repeat(depth);
+      const status = node.status ? ` [${node.status}]` : '';
+      const desc = node.description ? `\n${indent}    ${node.description}` : '';
+      lines.push(
+        `${indent}${TYPE_LABEL[node.type]}: ${node.name}${status} (id: ${node.id})${desc}`
+      );
+      for (const child of node.children) render(child, depth + 1);
+    };
+
+    for (const root of roots) render(root, 0);
+
+    if (orphans.length > 0) {
+      lines.push('');
+      lines.push(
+        `Orphans (parent missing from result set, ${orphans.length}):`
+      );
+      orphans.sort((a, b) => a.name.localeCompare(b.name));
+      for (const o of orphans) {
+        lines.push(
+          `  ${TYPE_LABEL[o.type]}: ${o.name} (id: ${o.id}, parentId: ${o.parentId ?? 'none'})`
+        );
+      }
+    }
+
+    const header = [
+      `Productboard hierarchy${archived ? ' (including archived)' : ''}:`,
+      `Totals — products: ${counts.product}, components: ${counts.component}, features: ${counts.feature}, subfeatures: ${counts.subfeature}`,
+      '',
+    ];
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: header.concat(lines).join('\n'),
+        },
+      ],
+    };
   }
 }

--- a/tests/unit/tools/products/product-hierarchy.test.ts
+++ b/tests/unit/tools/products/product-hierarchy.test.ts
@@ -172,11 +172,14 @@ describe('ProductHierarchyTool', () => {
       );
     });
 
-    it('lists orphans separately', async () => {
+    it('lists orphans separately and renders their child subtrees', async () => {
       mockApiClient.getAllPages
         .mockResolvedValueOnce([product('p1', 'Routific')])
         .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([feature('f-orphan', 'Lost feature', 'missing-parent-id')])
+        .mockResolvedValueOnce([
+          feature('f-orphan', 'Lost feature', 'missing-parent-id'),
+          feature('f-child', 'Child of orphan', 'f-orphan'),
+        ])
         .mockResolvedValueOnce([]);
 
       const result: any = await tool.execute({});
@@ -184,6 +187,8 @@ describe('ProductHierarchyTool', () => {
 
       expect(text).toContain('Orphans');
       expect(text).toContain('Lost feature');
+      expect(text).toContain('    Feature: Child of orphan');
+      expect(text).toContain('features: 2');
     });
 
     it('falls back to /entities/{id}/relationships?type=parent when the embedded relationships are missing the parent', async () => {
@@ -273,6 +278,36 @@ describe('ProductHierarchyTool', () => {
       // Should not start from products
       expect(text).not.toContain('Product: Routific');
       expect(text).not.toContain('Product: Other product');
+    });
+
+    it('preserves product_id as a backwards-compatible alias for root_id', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific'), product('p2', 'Other product')])
+        .mockResolvedValueOnce([component('c1', 'Routing', 'p1')])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({ product_id: 'p1' });
+      const text = result.content[0].text;
+
+      expect(text).toContain('Product: Routific');
+      expect(text).toContain('  Component: Routing');
+      expect(text).not.toContain('Product: Other product');
+    });
+
+    it('honors depth to limit rendered child levels', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([component('c1', 'Routing', 'p1')])
+        .mockResolvedValueOnce([feature('f1', 'Pickup-delivery pairing', 'c1')])
+        .mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({ depth: 1 });
+      const text = result.content[0].text;
+
+      expect(text).toContain('Product: Routific');
+      expect(text).toContain('  Component: Routing');
+      expect(text).not.toContain('Feature: Pickup-delivery pairing');
     });
 
     it('returns error when root_id is not found', async () => {

--- a/tests/unit/tools/products/product-hierarchy.test.ts
+++ b/tests/unit/tools/products/product-hierarchy.test.ts
@@ -186,6 +186,79 @@ describe('ProductHierarchyTool', () => {
       expect(text).toContain('Lost feature');
     });
 
+    it('falls back to /entities/{id}/relationships?type=parent when the embedded relationships are missing the parent', async () => {
+      // The PB API paginates relationships.data; an entity with many
+      // children listed first may not include its parent on page 1.
+      // Simulate that: this component has no parent in its embedded
+      // relationships, but the relationships endpoint returns the parent.
+      const orphanLooking = {
+        id: 'c-no-parent-in-data',
+        type: 'component',
+        fields: { name: 'UX issues in scheduling' },
+        relationships: { data: [] },
+      };
+
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Web App')])
+        .mockResolvedValueOnce([
+          component('c-parent', 'Scheduling orders to routes', 'p1'),
+          orphanLooking,
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      mockApiClient.get = jest.fn().mockResolvedValue({
+        data: [{ type: 'parent', target: { id: 'c-parent', type: 'component' } }],
+      });
+
+      const result: any = await tool.execute({});
+      const text = result.content[0].text;
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        '/entities/c-no-parent-in-data/relationships',
+        { type: 'parent' },
+      );
+      // Should be nested under Scheduling orders to routes, not in orphans
+      expect(text).toContain('Component: UX issues in scheduling');
+      expect(text).not.toContain('Orphans');
+    });
+
+    it('keeps an entity as orphan when both the embedded relationships and the fallback return no parent', async () => {
+      const trulyOrphan = {
+        id: 'really-orphan',
+        type: 'feature',
+        fields: { name: 'Genuinely lost' },
+        relationships: { data: [] },
+      };
+
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([trulyOrphan])
+        .mockResolvedValueOnce([]);
+
+      mockApiClient.get = jest.fn().mockResolvedValue({ data: [] });
+
+      const result: any = await tool.execute({});
+      const text = result.content[0].text;
+
+      expect(text).toContain('Orphans');
+      expect(text).toContain('Genuinely lost');
+    });
+
+    it('does not call the parent fallback for products', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      mockApiClient.get = jest.fn();
+
+      await tool.execute({});
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+
     it('starts from root_id when provided', async () => {
       mockApiClient.getAllPages
         .mockResolvedValueOnce([product('p1', 'Routific'), product('p2', 'Other product')])

--- a/tests/unit/tools/products/product-hierarchy.test.ts
+++ b/tests/unit/tools/products/product-hierarchy.test.ts
@@ -1,0 +1,260 @@
+import { ProductHierarchyTool } from '@tools/products/product-hierarchy';
+import { ProductboardAPIClient } from '@api/index';
+import { Logger } from '@utils/logger';
+
+describe('ProductHierarchyTool', () => {
+  let tool: ProductHierarchyTool;
+  let mockApiClient: jest.Mocked<ProductboardAPIClient>;
+  let mockLogger: jest.Mocked<Logger>;
+
+  const product = (id: string, name: string, parentId?: string) => ({
+    id,
+    type: 'product',
+    fields: { name },
+    relationships: parentId
+      ? { data: [{ type: 'parent', target: { id: parentId, type: 'product' } }] }
+      : { data: [] },
+  });
+
+  const component = (id: string, name: string, parentId: string, description?: string) => ({
+    id,
+    type: 'component',
+    fields: { name, description },
+    relationships: { data: [{ type: 'parent', target: { id: parentId, type: 'product' } }] },
+  });
+
+  const feature = (id: string, name: string, parentId: string, status?: string) => ({
+    id,
+    type: 'feature',
+    fields: {
+      name,
+      status: status ? { name: status } : undefined,
+    },
+    relationships: { data: [{ type: 'parent', target: { id: parentId } }] },
+  });
+
+  const subfeature = (id: string, name: string, parentId: string) => ({
+    id,
+    type: 'subfeature',
+    fields: { name },
+    relationships: { data: [{ type: 'parent', target: { id: parentId } }] },
+  });
+
+  beforeEach(() => {
+    mockApiClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      patch: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+      makeRequest: jest.fn(),
+      getAllPages: jest.fn(),
+    } as any;
+
+    mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+    } as any;
+
+    tool = new ProductHierarchyTool(mockApiClient, mockLogger);
+  });
+
+  describe('constructor', () => {
+    it('has correct name', () => {
+      expect(tool.name).toBe('pb_product_hierarchy');
+    });
+
+    it('description mentions all four levels', () => {
+      const d = tool.description;
+      expect(d).toContain('products');
+      expect(d).toContain('components');
+      expect(d).toContain('features');
+      expect(d).toContain('subfeatures');
+    });
+  });
+
+  describe('execute', () => {
+    it('fetches all four entity types in parallel by default', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      await tool.execute({});
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'product',
+        archived: false,
+      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'component',
+        archived: false,
+      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'feature',
+        archived: false,
+      });
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'subfeature',
+        archived: false,
+      });
+    });
+
+    it('skips features and subfeatures when include_features=false', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([]);
+
+      await tool.execute({ include_features: false });
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledTimes(2);
+    });
+
+    it('passes archived=true when requested', async () => {
+      mockApiClient.getAllPages.mockResolvedValue([]);
+
+      await tool.execute({ archived: true });
+
+      expect(mockApiClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'product',
+        archived: true,
+      });
+    });
+
+    it('builds nested tree from parent relationships', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([component('c1', 'Routing', 'p1')])
+        .mockResolvedValueOnce([feature('f1', 'Pickup-delivery pairing', 'c1', 'in_progress')])
+        .mockResolvedValueOnce([subfeature('sf1', 'Auto-assign drivers', 'f1')]);
+
+      const result: any = await tool.execute({});
+      const text = result.content[0].text;
+
+      // Tree structure with indentation
+      expect(text).toContain('Product: Routific');
+      expect(text).toContain('  Component: Routing');
+      expect(text).toContain('    Feature: Pickup-delivery pairing [in_progress]');
+      expect(text).toContain('      Subfeature: Auto-assign drivers');
+    });
+
+    it('sorts children alphabetically', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([
+          component('c1', 'Zebra', 'p1'),
+          component('c2', 'Alpha', 'p1'),
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({});
+      const text = result.content[0].text;
+      const alphaIdx = text.indexOf('Alpha');
+      const zebraIdx = text.indexOf('Zebra');
+
+      expect(alphaIdx).toBeLessThan(zebraIdx);
+    });
+
+    it('reports counts in the header', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific'), product('p2', 'Other')])
+        .mockResolvedValueOnce([component('c1', 'Routing', 'p1')])
+        .mockResolvedValueOnce([feature('f1', 'X', 'c1')])
+        .mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({});
+      expect(result.content[0].text).toContain(
+        'products: 2, components: 1, features: 1, subfeatures: 0'
+      );
+    });
+
+    it('lists orphans separately', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([feature('f-orphan', 'Lost feature', 'missing-parent-id')])
+        .mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({});
+      const text = result.content[0].text;
+
+      expect(text).toContain('Orphans');
+      expect(text).toContain('Lost feature');
+    });
+
+    it('starts from root_id when provided', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific'), product('p2', 'Other product')])
+        .mockResolvedValueOnce([component('c1', 'Routing', 'p1')])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({ root_id: 'c1' });
+      const text = result.content[0].text;
+
+      expect(text).toContain('Component: Routing');
+      // Should not start from products
+      expect(text).not.toContain('Product: Routific');
+      expect(text).not.toContain('Product: Other product');
+    });
+
+    it('returns error when root_id is not found', async () => {
+      mockApiClient.getAllPages.mockResolvedValue([]);
+
+      const result: any = await tool.execute({ root_id: 'unknown-id' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('unknown-id');
+    });
+
+    it('includes descriptions when include_descriptions=true', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([
+          component('c1', 'Routing', 'p1', 'Handles automatic route optimization for fleets.'),
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({ include_descriptions: true });
+      expect(result.content[0].text).toContain(
+        'Handles automatic route optimization'
+      );
+    });
+
+    it('omits descriptions when include_descriptions is not set', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([
+          component('c1', 'Routing', 'p1', 'Handles automatic route optimization for fleets.'),
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({});
+      expect(result.content[0].text).not.toContain('Handles automatic');
+    });
+
+    it('strips HTML from descriptions', async () => {
+      mockApiClient.getAllPages
+        .mockResolvedValueOnce([product('p1', 'Routific')])
+        .mockResolvedValueOnce([
+          component('c1', 'Routing', 'p1', '<p>Handles <b>routing</b>.</p>'),
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const result: any = await tool.execute({ include_descriptions: true });
+      const text = result.content[0].text;
+
+      expect(text).toMatch(/Handles routing\s?\./);
+      expect(text).not.toContain('<p>');
+      expect(text).not.toContain('<b>');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Expected behaviour was that `pb_product_hierarchy` would return the full tree of products, components, features, and subfeatures so Claude can use it as context when matching a note to a feature.

What didn't work: the tool only queried `type=product`, expected the API to return a nested `children` array (the v2 API doesn't nest; it returns one parent per entity in `relationships.data`), and passed `parent_id` instead of `parent[id]`. The result was a flat list of product names.

What this change does: fetches all four entity types in parallel, reads the parent from `relationships.data` where `type=parent`, and builds the tree client-side. Each node shows id, name, and status. Descriptions are off by default to keep the payload light, but can be requested via `include_descriptions: true` to give Claude richer context about what each node is. Entities whose parent isn't in the result set are listed separately as orphans.

## Test plan
- [ ] Run `npm test` to confirm all tests pass (327 total).
- [ ] Call `pb_product_hierarchy` with no params, confirm products, components, features, and subfeatures appear nested.
- [ ] Call with `include_features: false`, confirm only products and components are returned.
- [ ] Call with `include_descriptions: true`, confirm each node includes its description.
- [ ] Call with `root_id` set to a known component UUID, confirm tree starts from that node.
