### PR TITLE
Add pb_note_search to find notes by linked feature or customer

### DIFF
--- a/src/tools/notes/index.ts
+++ b/src/tools/notes/index.ts
@@ -1,3 +1,4 @@
 export { CreateNoteTool } from './create-note.js';
 export { ListNotesTool } from './list-notes.js';
 export { UpdateNoteTool } from './update-note.js';
+export { SearchNotesTool } from './search-notes.js';

--- a/src/tools/notes/search-notes.ts
+++ b/src/tools/notes/search-notes.ts
@@ -1,0 +1,199 @@
+import { BaseTool } from '../base.js';
+import { ProductboardAPIClient } from '@api/index.js';
+import { Logger } from '@utils/logger.js';
+import { Permission, AccessLevel } from '@auth/permissions.js';
+
+interface SearchNotesParams {
+  feature_id?: string;
+  customer_id?: string;
+  tag?: string;
+  processed?: boolean;
+  archived?: boolean;
+  created_from?: string;
+  created_to?: string;
+  limit?: number;
+}
+
+const stripHtml = (s: string): string =>
+  s
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const truncate = (s: string, max: number): string =>
+  s.length > max ? s.slice(0, max - 1).trimEnd() + '…' : s;
+
+export class SearchNotesTool extends BaseTool<SearchNotesParams> {
+  constructor(apiClient: ProductboardAPIClient, logger: Logger) {
+    super(
+      'pb_note_search',
+      'Search for notes filtered by their relationships (linked feature, linked customer) and/or attributes (tag, processed, created date). Use this to answer questions like "what insights are tagged to feature X?" (pass feature_id), "what has customer Y told us?" (pass customer_id, works for both user and company UUIDs), or "has anyone from this company given feedback on this feature?" (pass both). For finding unprocessed notes to work through, use pb_note_list instead — that one is for working the queue, this one is for investigating a specific relationship.',
+      {
+        type: 'object',
+        properties: {
+          feature_id: {
+            type: 'string',
+            description: 'Filter to notes linked to this feature, component, or subfeature UUID.',
+          },
+          customer_id: {
+            type: 'string',
+            description: 'Filter to notes linked to this user or company UUID. Use pb_customer_lookup first to find the UUID.',
+          },
+          tag: {
+            type: 'string',
+            description: 'Filter to notes with this tag.',
+          },
+          processed: {
+            type: 'boolean',
+            description: 'Filter by processed state.',
+          },
+          archived: {
+            type: 'boolean',
+            description: 'Include archived notes (default false).',
+          },
+          created_from: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Filter notes created from this date-time onwards.',
+          },
+          created_to: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Filter notes created up to this date-time.',
+          },
+          limit: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 200,
+            default: 20,
+            description: 'Maximum number of notes to return (default 20).',
+          },
+        },
+      },
+      {
+        requiredPermissions: [Permission.NOTES_READ],
+        minimumAccessLevel: AccessLevel.READ,
+        description: 'Requires read access to notes',
+      },
+      apiClient,
+      logger
+    );
+  }
+
+  protected async executeInternal(params: SearchNotesParams = {}): Promise<unknown> {
+    const filter: Record<string, any> = {};
+
+    if (params.feature_id) {
+      filter.relationships ??= {};
+      filter.relationships.link = [{ id: params.feature_id }];
+    }
+    if (params.customer_id) {
+      filter.relationships ??= {};
+      filter.relationships.customer = [{ id: params.customer_id }];
+    }
+    if (params.tag) {
+      filter.fields ??= {};
+      filter.fields.tag = params.tag;
+    }
+    if (params.processed !== undefined) {
+      filter.fields ??= {};
+      filter.fields.processed = params.processed;
+    }
+    if (params.archived !== undefined) {
+      filter.fields ??= {};
+      filter.fields.archived = params.archived;
+    }
+    if (params.created_from || params.created_to) {
+      filter.createdAt = {};
+      if (params.created_from) filter.createdAt.from = params.created_from;
+      if (params.created_to) filter.createdAt.to = params.created_to;
+    }
+
+    if (Object.keys(filter).length === 0) {
+      return {
+        success: false,
+        error:
+          'At least one filter is required. Provide feature_id, customer_id, tag, processed, archived, or a date range. For an unfiltered listing, use pb_note_list.',
+      };
+    }
+
+    const limit = params.limit ?? 20;
+
+    const response = await this.apiClient.post('/notes/search', {
+      data: { filter },
+    });
+
+    const allNotes: any[] = (response as any).data ?? [];
+    const notes = allNotes.slice(0, limit);
+
+    const formatted = notes.map((n: any) => {
+      const rels = n.relationships?.data ?? [];
+      const customers = rels
+        .filter((r: any) => r.type === 'customer')
+        .map((r: any) => r.target?.id)
+        .filter(Boolean);
+      const linkedFeatures = rels
+        .filter((r: any) => r.type === 'link')
+        .map((r: any) => ({
+          id: r.target?.id,
+          type: r.target?.type,
+        }))
+        .filter((f: any) => f.id);
+
+      const rawContent = n.fields?.content ? stripHtml(n.fields.content) : '';
+      const title =
+        n.fields?.name?.trim() ||
+        (rawContent ? rawContent.slice(0, 60) : 'Untitled note');
+
+      return {
+        id: n.id,
+        title,
+        content: truncate(rawContent, 400),
+        owner: n.fields?.owner?.email ?? null,
+        createdAt: n.createdAt,
+        processed: n.fields?.processed ?? null,
+        customers,
+        linkedFeatures,
+      };
+    });
+
+    if (notes.length === 0) {
+      return {
+        content: [
+          { type: 'text', text: 'No notes matched the supplied filters.' },
+        ],
+      };
+    }
+
+    const lines: string[] = [
+      `Found ${allNotes.length} note${allNotes.length === 1 ? '' : 's'}, showing ${notes.length}:`,
+      '',
+    ];
+
+    for (const [i, n] of formatted.entries()) {
+      lines.push(`${i + 1}. ${n.title}`);
+      lines.push(`   ID: ${n.id}`);
+      lines.push(`   Created: ${n.createdAt}`);
+      if (n.processed !== null) lines.push(`   Processed: ${n.processed}`);
+      if (n.owner) lines.push(`   Owner: ${n.owner}`);
+      if (n.customers.length > 0)
+        lines.push(`   Customer IDs: ${n.customers.join(', ')}`);
+      if (n.linkedFeatures.length > 0) {
+        const linkStrs = n.linkedFeatures.map(
+          (f: any) => `${f.type}:${f.id}`,
+        );
+        lines.push(`   Linked: ${linkStrs.join(', ')}`);
+      }
+      lines.push(`   Content: ${n.content}`);
+      lines.push('');
+    }
+
+    return {
+      content: [{ type: 'text', text: lines.join('\n') }],
+    };
+  }
+}

--- a/src/tools/notes/search-notes.ts
+++ b/src/tools/notes/search-notes.ts
@@ -24,9 +24,6 @@ const stripHtml = (s: string): string =>
     .replace(/\s+/g, ' ')
     .trim();
 
-const truncate = (s: string, max: number): string =>
-  s.length > max ? s.slice(0, max - 1).trimEnd() + '…' : s;
-
 export class SearchNotesTool extends BaseTool<SearchNotesParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
@@ -152,7 +149,7 @@ export class SearchNotesTool extends BaseTool<SearchNotesParams> {
       return {
         id: n.id,
         title,
-        content: truncate(rawContent, 400),
+        content: rawContent,
         owner: n.fields?.owner?.email ?? null,
         createdAt: n.createdAt,
         processed: n.fields?.processed ?? null,

--- a/tests/unit/tools/notes/search-notes.test.ts
+++ b/tests/unit/tools/notes/search-notes.test.ts
@@ -1,0 +1,197 @@
+import { SearchNotesTool } from '@tools/notes/search-notes';
+import { ProductboardAPIClient } from '@api/index';
+import { Logger } from '@utils/logger';
+
+describe('SearchNotesTool', () => {
+  let tool: SearchNotesTool;
+  let mockApiClient: jest.Mocked<ProductboardAPIClient>;
+  let mockLogger: jest.Mocked<Logger>;
+
+  const FEATURE_ID = 'ea5e764a-bcf0-4ae2-abaa-baba0f5a3e8c';
+  const CUSTOMER_ID = 'e40d7127-8315-4214-b750-300e93b1b2a2';
+
+  beforeEach(() => {
+    mockApiClient = {
+      get: jest.fn(),
+      post: jest.fn().mockResolvedValue({ data: [] }),
+      patch: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+      makeRequest: jest.fn(),
+      getAllPages: jest.fn(),
+    } as any;
+
+    mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+    } as any;
+
+    tool = new SearchNotesTool(mockApiClient, mockLogger);
+  });
+
+  const parse = (result: any) => {
+    try {
+      return JSON.parse(result.content[0].text);
+    } catch {
+      return null;
+    }
+  };
+
+  describe('constructor', () => {
+    it('has correct name', () => {
+      expect(tool.name).toBe('pb_note_search');
+    });
+
+    it('description distinguishes from pb_note_list', () => {
+      expect(tool.description).toContain('pb_note_list');
+    });
+  });
+
+  describe('execute', () => {
+    it('requires at least one filter', async () => {
+      const result = await tool.execute({});
+      const parsed = parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('At least one filter');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('builds correct payload for feature_id', async () => {
+      await tool.execute({ feature_id: FEATURE_ID });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith('/notes/search', {
+        data: {
+          filter: {
+            relationships: { link: [{ id: FEATURE_ID }] },
+          },
+        },
+      });
+    });
+
+    it('builds correct payload for customer_id', async () => {
+      await tool.execute({ customer_id: CUSTOMER_ID });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith('/notes/search', {
+        data: {
+          filter: {
+            relationships: { customer: [{ id: CUSTOMER_ID }] },
+          },
+        },
+      });
+    });
+
+    it('combines feature_id and customer_id under relationships', async () => {
+      await tool.execute({ feature_id: FEATURE_ID, customer_id: CUSTOMER_ID });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith('/notes/search', {
+        data: {
+          filter: {
+            relationships: {
+              link: [{ id: FEATURE_ID }],
+              customer: [{ id: CUSTOMER_ID }],
+            },
+          },
+        },
+      });
+    });
+
+    it('puts tag, processed, archived under fields', async () => {
+      await tool.execute({
+        feature_id: FEATURE_ID,
+        tag: 'beta',
+        processed: false,
+        archived: false,
+      });
+
+      const callBody = (mockApiClient.post as jest.Mock).mock.calls[0][1] as any;
+      expect(callBody.data.filter.fields).toEqual({
+        tag: 'beta',
+        processed: false,
+        archived: false,
+      });
+    });
+
+    it('puts date range under createdAt', async () => {
+      await tool.execute({
+        feature_id: FEATURE_ID,
+        created_from: '2026-01-01T00:00:00Z',
+        created_to: '2026-12-31T23:59:59Z',
+      });
+
+      const callBody = (mockApiClient.post as jest.Mock).mock.calls[0][1] as any;
+      expect(callBody.data.filter.createdAt).toEqual({
+        from: '2026-01-01T00:00:00Z',
+        to: '2026-12-31T23:59:59Z',
+      });
+    });
+
+    it('returns "no notes matched" when API returns empty array', async () => {
+      mockApiClient.post.mockResolvedValueOnce({ data: [] });
+
+      const result: any = await tool.execute({ feature_id: FEATURE_ID });
+      expect(result.content[0].text).toContain('No notes matched');
+    });
+
+    it('renders notes with id, content, customer and linked features', async () => {
+      mockApiClient.post.mockResolvedValueOnce({
+        data: [
+          {
+            id: 'note-1',
+            createdAt: '2026-04-01T00:00:00Z',
+            fields: {
+              content: '<p>Customer needs better reporting</p>',
+              processed: false,
+              owner: { email: 'sophie@routific.com' },
+            },
+            relationships: {
+              data: [
+                {
+                  type: 'customer',
+                  target: { id: CUSTOMER_ID, type: 'user' },
+                },
+                {
+                  type: 'link',
+                  target: { id: FEATURE_ID, type: 'feature' },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const result: any = await tool.execute({ feature_id: FEATURE_ID });
+      const text = result.content[0].text;
+
+      expect(text).toContain('note-1');
+      expect(text).toContain('Customer needs better reporting');
+      expect(text).toContain(CUSTOMER_ID);
+      expect(text).toContain(`feature:${FEATURE_ID}`);
+      expect(text).toContain('sophie@routific.com');
+      expect(text).toContain('Processed: false');
+    });
+
+    it('respects limit on results returned', async () => {
+      const manyNotes = Array.from({ length: 5 }, (_, i) => ({
+        id: `note-${i}`,
+        createdAt: '2026-04-01T00:00:00Z',
+        fields: { content: `note ${i}` },
+        relationships: { data: [] },
+      }));
+      mockApiClient.post.mockResolvedValueOnce({ data: manyNotes });
+
+      const result: any = await tool.execute({
+        feature_id: FEATURE_ID,
+        limit: 2,
+      });
+      const text = result.content[0].text;
+
+      expect(text).toContain('Found 5 notes, showing 2');
+      expect(text).toContain('note-0');
+      expect(text).toContain('note-1');
+      expect(text).not.toContain('note-2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Expected behaviour: when looking at a feature, Claude should be able to see what insights are already tagged to it. When looking at a customer, Claude should be able to see what they've asked for and which features that feedback was tagged to.

What didn't work: `pb_note_list` uses `GET /v2/notes`, which only filters by note attributes (processed, archived, dates, owner). It can't filter by linked feature or linked customer. `POST /v2/notes/search` supports both, but no tool was wrapping it.

What this change does: adds `pb_note_search` wrapping `POST /notes/search` with filters for `feature_id`, `customer_id`, `tag`, `processed`, `archived`, and a date range. `customer_id` accepts a user or company UUID; `feature_id` accepts a feature, component, or subfeature UUID. Pair with `pb_product_hierarchy` to find a feature, `pb_customer_lookup` to find a customer, then this tool to surface the relevant notes.

## Test plan
- [ ] Run `npm test`, confirm all tests pass.
- [ ] Call `pb_note_search` with no filters, confirm the error message points the caller at `pb_note_list`.
- [ ] Call with `feature_id` for a known feature, confirm linked notes return.
- [ ] Call with `customer_id` for a known customer, confirm their notes return.
- [ ] Call with both `feature_id` and `customer_id`, confirm intersection.
