### PR TITLE
Tighten tool descriptions to prevent common Claude mistakes

### DIFF
--- a/src/tools/features/get-feature.ts
+++ b/src/tools/features/get-feature.ts
@@ -12,7 +12,7 @@ export class GetFeatureTool extends BaseTool<GetFeatureParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
       'pb_feature_get',
-      'Get detailed information about a specific feature',
+      'Get the full details of a single feature by UUID: name, description, status, owner, parent component/product, and any custom fields. Use this when you have a candidate feature and want to read its full description before deciding it fits a note. To see what feedback is already linked to this feature, pair with pb_note_search using `feature_id` set to the same UUID — that is how you check whether existing insights describe a similar need to the one you are about to tag.',
       {
         type: 'object',
         required: ['id'],

--- a/src/tools/features/get-feature.ts
+++ b/src/tools/features/get-feature.ts
@@ -12,7 +12,7 @@ export class GetFeatureTool extends BaseTool<GetFeatureParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
       'pb_feature_get',
-      'Get the full details of a single feature by UUID: name, description, status, owner, parent component/product, and any custom fields. Use this when you have a candidate feature and want to read its full description before deciding it fits a note. To see what feedback is already linked to this feature, pair with pb_note_search using `feature_id` set to the same UUID — that is how you check whether existing insights describe a similar need to the one you are about to tag.',
+      'Get Productboard details for a single feature by UUID, including fields returned by the API such as name, description, status, owner, parent relationships, and requested includes. Use this when you have a candidate feature and want to read its description before deciding it fits a note. To inspect linked feedback, first use this feature UUID with a note-search workflow/tool when available, or list notes and inspect their link relationships.',
       {
         type: 'object',
         required: ['id'],

--- a/src/tools/features/list-features.ts
+++ b/src/tools/features/list-features.ts
@@ -19,7 +19,7 @@ export class ListFeaturesTool extends BaseTool<ListFeaturesParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
       'pb_feature_list',
-      'List features with optional filtering and pagination',
+      'List features filtered by attributes (name, status, owner, parent, archived). Returns the full result set across all pages — the count shown is the actual total, not a first-page snapshot. Archived features are excluded by default. The `name` filter does literal substring matching (case-insensitive, exact on whitespace and punctuation), so it is good for narrow lookups but bad for discovery. To explore the product structure or find candidate features for a note, use pb_product_hierarchy instead — that returns the whole tree and lets you walk it rather than guess keywords.',
       {
         type: 'object',
         properties: {

--- a/src/tools/features/list-features.ts
+++ b/src/tools/features/list-features.ts
@@ -19,7 +19,7 @@ export class ListFeaturesTool extends BaseTool<ListFeaturesParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
       'pb_feature_list',
-      'List features filtered by attributes (name, status, owner, parent, archived). Returns the full result set across all pages — the count shown is the actual total, not a first-page snapshot. Archived features are excluded by default. The `name` filter does literal substring matching (case-insensitive, exact on whitespace and punctuation), so it is good for narrow lookups but bad for discovery. To explore the product structure or find candidate features for a note, use pb_product_hierarchy instead — that returns the whole tree and lets you walk it rather than guess keywords.',
+      'List features filtered by attributes (name, status, owner, parent, archived). Fetches all API pages to compute the actual total, then returns up to `limit` results starting at `offset`; the output count is not just a first-page snapshot. Archived features are excluded by default. The `name` filter does literal substring matching (case-insensitive, exact on whitespace and punctuation), so it is good for narrow lookups but bad for discovery. To explore the product structure or find candidate features for a note, use pb_product_hierarchy instead — that returns the tree and lets you walk it rather than guess keywords.',
       {
         type: 'object',
         properties: {

--- a/src/tools/notes/create-note.ts
+++ b/src/tools/notes/create-note.ts
@@ -23,7 +23,7 @@ export class CreateNoteTool extends BaseTool<CreateNoteParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
       'pb_note_create',
-      'Create a customer feedback note with automatic customer/company lookup',
+      'Create a new customer feedback note. Linking a note to one or more features is done by passing their UUIDs in `feature_ids` — this creates structural "link" relationships between the note and each feature. The `tags` field is unrelated to feature linking: tags are workspace-defined string labels (e.g. "beta", "churned") that must already exist in the workspace; passing feature names there will not link the note to a feature. Customer linking happens automatically when `customer_email` matches an existing user; set `create_if_missing: true` to create the user/company on the fly. Use this for new notes only — to add feature links or mark an existing note processed, use pb_note_update.',
       {
         type: 'object',
         required: ['content'],

--- a/src/tools/notes/list-notes.ts
+++ b/src/tools/notes/list-notes.ts
@@ -24,7 +24,7 @@ export class ListNotesTool extends BaseTool<ListNotesParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
       'pb_note_list',
-      'List customer feedback notes',
+      'List customer feedback notes, optionally filtered by note attributes (processed, archived, dates, owner, source). Returns the full result set across all pages — the count shown is the actual total. Each note in the output includes its UUID, content, owner, and creation timestamp; pass the UUID to pb_note_update when processing. This tool CANNOT filter by linked feature or linked customer. For "what insights are tagged to feature X" or "what has customer Y told us," use pb_note_search.',
       {
         type: 'object',
         properties: {

--- a/src/tools/notes/list-notes.ts
+++ b/src/tools/notes/list-notes.ts
@@ -24,7 +24,7 @@ export class ListNotesTool extends BaseTool<ListNotesParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
       'pb_note_list',
-      'List customer feedback notes, optionally filtered by note attributes (processed, archived, dates, owner, source). Returns the full result set across all pages — the count shown is the actual total. Each note in the output includes its UUID, content, owner, and creation timestamp; pass the UUID to pb_note_update when processing. This tool CANNOT filter by linked feature or linked customer. For "what insights are tagged to feature X" or "what has customer Y told us," use pb_note_search.',
+      'List customer feedback notes, optionally filtered by note attributes (processed, archived, dates, owner, source). Fetches all API pages to compute the actual total, then returns up to `limit` results starting at `offset`. Each note in the output includes its UUID, content, owner, and creation timestamp; pass the UUID to pb_note_update when processing. This tool filters note attributes only; to investigate notes linked to a specific feature or customer, use a relationship-aware note search tool/workflow when available.',
       {
         type: 'object',
         properties: {

--- a/src/tools/notes/update-note.ts
+++ b/src/tools/notes/update-note.ts
@@ -19,7 +19,7 @@ export class UpdateNoteTool extends BaseTool<UpdateNoteParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
       'pb_note_update',
-      'Update an existing note: link it to features and/or mark it processed. Use this once you\'ve extracted insights from a note and identified which features it relates to.',
+      'Update an existing note: link it to one or more features (via `link_feature_ids`, which creates structural "link" relationships) and/or mark it processed. The order matters: linking happens first, and `processed` is only applied if every link succeeds, so a note never appears done while its feature linking is incomplete. This is unrelated to the `tags` field on pb_note_create — tags are workspace string labels, not feature pointers. Use this once you have identified which features a note should be linked to.',
       {
         type: 'object',
         required: ['id'],

--- a/tests/integration/tools/tool-registration.test.ts
+++ b/tests/integration/tools/tool-registration.test.ts
@@ -136,7 +136,7 @@ describe('Tool Registration Integration', () => {
       expect(descriptors).toContainEqual(
         expect.objectContaining({
           name: 'pb_feature_get',
-          description: expect.stringContaining('full details of a single feature'),
+          description: expect.stringContaining('details for a single feature'),
         })
       );
       expect(descriptors).toContainEqual(

--- a/tests/integration/tools/tool-registration.test.ts
+++ b/tests/integration/tools/tool-registration.test.ts
@@ -136,7 +136,7 @@ describe('Tool Registration Integration', () => {
       expect(descriptors).toContainEqual(
         expect.objectContaining({
           name: 'pb_feature_get',
-          description: 'Get detailed information about a specific feature',
+          description: expect.stringContaining('full details of a single feature'),
         })
       );
       expect(descriptors).toContainEqual(
@@ -148,7 +148,7 @@ describe('Tool Registration Integration', () => {
       expect(descriptors).toContainEqual(
         expect.objectContaining({
           name: 'pb_note_create',
-          description: 'Create a customer feedback note with automatic customer/company lookup',
+          description: expect.stringContaining('Create a new customer feedback note'),
         })
       );
     });

--- a/tests/unit/tools/features/list-features.test.ts
+++ b/tests/unit/tools/features/list-features.test.ts
@@ -46,7 +46,7 @@ describe('ListFeaturesTool', () => {
   describe('metadata', () => {
     it('should have correct name and description', () => {
       expect(tool.name).toBe('pb_feature_list');
-      expect(tool.description).toBe('List features with optional filtering and pagination');
+      expect(tool.description).toContain('List features');
     });
 
     it('should have correct parameter schema', () => {

--- a/tests/unit/tools/notes/create-note.test.ts
+++ b/tests/unit/tools/notes/create-note.test.ts
@@ -39,7 +39,7 @@ describe('CreateNoteTool', () => {
   describe('constructor', () => {
     it('should initialize with correct name and description', () => {
       expect(tool.name).toBe('pb_note_create');
-      expect(tool.description).toBe('Create a customer feedback note with automatic customer/company lookup');
+      expect(tool.description).toContain('Create a new customer feedback note');
     });
 
     it('should define correct parameters schema', () => {

--- a/tests/unit/tools/notes/list-notes.test.ts
+++ b/tests/unit/tools/notes/list-notes.test.ts
@@ -28,7 +28,7 @@ describe('ListNotesTool', () => {
   describe('constructor', () => {
     it('should initialize with correct name and description', () => {
       expect(tool.name).toBe('pb_note_list');
-      expect(tool.description).toBe('List customer feedback notes');
+      expect(tool.description).toContain('List customer feedback notes');
     });
 
     it('should define correct parameters schema', () => {


### PR DESCRIPTION
## Summary

I'm finding that Claude is making obvious mistakes when using some of the tools, and it's suggesting a stronger tool description should help. The kinds of issues I'm seeing are:

1. Claude grabs a list tool's first page and treats it as the full dataset, until I prompt and realize it's missing data I know exists.
2. Claude confused the tags field with using `link_feature_ids` to link the note to a feature. Might be my misuse of the words "tagging to features" but I want to disambiguate these for it.

I'm proposing longer descriptions that spell out pagination behaviour, make the tags field vs feature links distinction explicit on every relevant tool, name the companion tools for related needs, and steer discovery toward `pb_product_hierarchy` instead of relying on keyword-searching `pb_feature_list` alone.

## Test plan
- [ ] Run `npm test`, confirm all tests pass.
- [ ] Ask Claude to "list unprocessed notes" and confirm it doesn't claim the list is truncated.
- [ ] Ask Claude to "tag this note to feature X" and confirm it calls `pb_note_update` with `link_feature_ids`, not `pb_note_create` with `tags`.
- [ ] Ask Claude to "find a feature about X" and confirm it reaches for `pb_product_hierarchy`, not `pb_feature_list` with a keyword.
