### PR TITLE
fix: improve feature create/update and objective context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -973,6 +973,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
       "dev": true,
@@ -3104,6 +3128,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "9.6.1",
@@ -5527,6 +5575,16 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "dev": true,
@@ -6427,6 +6485,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,13 @@
     "pino-pretty": "^10.2.3"
   },
   "overrides": {
-    "ajv": ">=6.14.0",
+    "ajv": "^8.17.1",
+    "eslint": {
+      "ajv": "^6.12.6"
+    },
+    "@eslint/eslintrc": {
+      "ajv": "^6.12.6"
+    },
     "minimatch": ">=9.0.7",
     "js-yaml": ">=4.1.1",
     "form-data": ">=4.0.4",

--- a/src/tools/features/create-feature.ts
+++ b/src/tools/features/create-feature.ts
@@ -2,7 +2,12 @@ import { BaseTool } from '../base.js';
 import { ProductboardAPIClient } from '@api/client.js';
 import { Logger } from '@utils/logger.js';
 import { Permission, AccessLevel } from '@auth/permissions.js';
+import { ValidationResult } from '../../middleware/types.js';
 import { FeaturePayload } from './types.js';
+
+interface ProductboardResponseEnvelope {
+  data?: unknown;
+}
 
 export class CreateFeatureTool extends BaseTool<FeaturePayload> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
@@ -53,18 +58,44 @@ export class CreateFeatureTool extends BaseTool<FeaturePayload> {
         description: 'Requires write access to create features',
       },
       apiClient,
-      logger
+      logger,
     );
+  }
+
+  validateParams(params: unknown): ValidationResult {
+    const baseValidation = super.validateParams(params);
+    if (!baseValidation.valid) {
+      return baseValidation;
+    }
+
+    const featureParams = params as FeaturePayload;
+    if (!featureParams.product_id && !featureParams.component_id) {
+      return {
+        valid: false,
+        errors: [
+          {
+            path: 'product_id',
+            message:
+              'Either product_id or component_id must be provided as the parent entity for a feature',
+            value: undefined,
+          },
+        ],
+      };
+    }
+
+    return { valid: true, errors: [] };
   }
 
   protected async executeInternal(params: FeaturePayload): Promise<unknown> {
     const { owner_email, product_id, component_id, ...rest } = params;
 
-    const toHtml = (text: string) => text.startsWith('<') ? text : `<p>${text}</p>`;
+    const toHtml = (text: string): string => (text.startsWith('<') ? text : `<p>${text}</p>`);
 
     const fields: Record<string, unknown> = { ...rest };
     if (fields.description) fields.description = toHtml(fields.description as string);
     if (owner_email) fields.owner = { email: owner_email };
+    if (Array.isArray(fields.tags))
+      fields.tags = (fields.tags as string[]).map((name) => ({ name }));
 
     const relationships: Array<{ type: string; target: { id: string } }> = [];
     if (component_id) relationships.push({ type: 'parent', target: { id: component_id } });
@@ -75,9 +106,11 @@ export class CreateFeatureTool extends BaseTool<FeaturePayload> {
 
     const response = await this.apiClient.post('/entities', { data: requestData });
 
+    const responseEnvelope = response as ProductboardResponseEnvelope;
+
     return {
       success: true,
-      data: (response as any).data || response,
+      data: responseEnvelope.data ?? response,
     };
   }
 }

--- a/src/tools/features/update-feature.ts
+++ b/src/tools/features/update-feature.ts
@@ -2,6 +2,11 @@ import { BaseTool } from '../base.js';
 import { ProductboardAPIClient } from '@api/client.js';
 import { Logger } from '@utils/logger.js';
 import { Permission, AccessLevel } from '@auth/permissions.js';
+import { ValidationResult } from '../../middleware/types.js';
+
+interface ProductboardResponseEnvelope {
+  data?: unknown;
+}
 
 interface UpdateFeatureParams {
   id: string;
@@ -36,7 +41,8 @@ export class UpdateFeatureTool extends BaseTool<UpdateFeatureParams> {
           },
           status_id: {
             type: 'string',
-            description: 'Status ID (UUID from the status object on the feature, e.g. from pb_feature_get)',
+            description:
+              'Status ID (UUID from the status object on the feature, e.g. from pb_feature_get)',
           },
           owner_email: {
             type: 'string',
@@ -56,26 +62,29 @@ export class UpdateFeatureTool extends BaseTool<UpdateFeatureParams> {
         description: 'Requires write access to features',
       },
       apiClient,
-      logger
+      logger,
     );
   }
 
-  validateParams(params: unknown) {
+  validateParams(params: unknown): ValidationResult {
     const baseValidation = super.validateParams(params);
     if (!baseValidation.valid) {
       return baseValidation;
     }
 
     // Additional validation: ensure at least one field to update
-    const { id, ...updateFields } = params as UpdateFeatureParams;
+    const { id: ignoredId, ...updateFields } = params as UpdateFeatureParams;
+    void ignoredId;
     if (Object.keys(updateFields).length === 0) {
       return {
         valid: false,
-        errors: [{
-          path: '',
-          message: 'At least one field must be provided for update',
-          value: undefined,
-        }],
+        errors: [
+          {
+            path: '',
+            message: 'At least one field must be provided for update',
+            value: undefined,
+          },
+        ],
       };
     }
 
@@ -87,15 +96,22 @@ export class UpdateFeatureTool extends BaseTool<UpdateFeatureParams> {
 
     const { owner_email, status_id, ...rest } = updateData as Record<string, unknown>;
     const fields: Record<string, unknown> = { ...rest };
-    if (fields.description) fields.description = (fields.description as string).startsWith('<') ? fields.description : `<p>${fields.description}</p>`;
+    const description = fields.description;
+    if (typeof description === 'string') {
+      fields.description = description.startsWith('<') ? description : `<p>${description}</p>`;
+    }
     if (owner_email) fields.owner = { email: owner_email };
     if (status_id) fields.status = { id: status_id };
+    if (Array.isArray(fields.tags))
+      fields.tags = (fields.tags as string[]).map((name) => ({ name }));
 
     const response = await this.apiClient.patch(`/entities/${id}`, { data: { fields } });
 
+    const responseEnvelope = response as ProductboardResponseEnvelope;
+
     return {
       success: true,
-      data: (response as any).data || response,
+      data: responseEnvelope.data ?? response,
     };
   }
 }

--- a/src/tools/objectives/list-objectives.ts
+++ b/src/tools/objectives/list-objectives.ts
@@ -11,6 +11,17 @@ interface ListObjectivesParams {
   offset?: number;
 }
 
+interface ObjectiveEntity {
+  fields?: {
+    name?: string;
+    description?: string;
+    status?: { name?: string } | string;
+    owner?: { email?: string };
+  };
+}
+
+type ObjectiveStatus = { name?: string } | string | undefined;
+
 export class ListObjectivesTool extends BaseTool<ListObjectivesParams> {
   constructor(apiClient: ProductboardAPIClient, logger: Logger) {
     super(
@@ -55,7 +66,7 @@ export class ListObjectivesTool extends BaseTool<ListObjectivesParams> {
         description: 'Requires read access to objectives',
       },
       apiClient,
-      logger
+      logger,
     );
   }
 
@@ -63,28 +74,43 @@ export class ListObjectivesTool extends BaseTool<ListObjectivesParams> {
     this.logger.info('Listing objectives');
 
     // Only pass filters supported by the API, not pagination params
-    const queryParams: Record<string, any> = { 'type[]': 'objective' };
+    const queryParams: Record<string, string> = { 'type[]': 'objective' };
     if (params.status) queryParams.status = params.status;
     if (params.owner_email) queryParams.owner_email = params.owner_email;
     if (params.period) queryParams.period = params.period;
 
-    const allObjectives: any[] = await this.apiClient.getAllPages<any>('/entities', queryParams);
-    const limit = params.limit || 20;
-    const offset = params.offset || 0;
+    const allObjectives = await this.apiClient.getAllPages<ObjectiveEntity>(
+      '/entities',
+      queryParams,
+    );
+    const limit = params.limit ?? 20;
+    const offset = params.offset ?? 0;
     const objectives = allObjectives.slice(offset, offset + limit);
 
-    const stripHtml = (s: string) => s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+    const stripHtml = (s: string): string =>
+      s
+        .replace(/<[^>]*>/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
 
-    const formatted = objectives.map((obj: any, i: number) =>
-      `${offset + i + 1}. ${obj.fields?.name || 'Untitled Objective'}\n` +
-      `   Status: ${obj.fields?.status?.name || (typeof obj.fields?.status === 'string' ? obj.fields.status : 'Unknown')}\n` +
-      `   Owner: ${obj.fields?.owner?.email || 'Unassigned'}\n` +
-      (obj.fields?.description ? `   Description: ${stripHtml(obj.fields.description).substring(0, 120)}\n` : '')
+    const getStatusName = (status: ObjectiveStatus): string => {
+      if (typeof status === 'string') return status;
+      return status?.name ?? 'Unknown';
+    };
+
+    const formatted = objectives.map(
+      (obj: ObjectiveEntity, i: number) =>
+        `${offset + i + 1}. ${obj.fields?.name ?? 'Untitled Objective'}\n` +
+        `   Status: ${getStatusName(obj.fields?.status)}\n` +
+        `   Owner: ${obj.fields?.owner?.email ?? 'Unassigned'}\n` +
+        (obj.fields?.description ? `   Description: ${stripHtml(obj.fields.description)}\n` : ''),
     );
 
-    const summary = objectives.length > 0
-      ? `Found ${allObjectives.length} objectives, showing ${objectives.length}:\n\n` + formatted.join('\n')
-      : 'No objectives found.';
+    const summary =
+      objectives.length > 0
+        ? `Found ${allObjectives.length} objectives, showing ${objectives.length}:\n\n` +
+          formatted.join('\n')
+        : 'No objectives found.';
 
     return { content: [{ type: 'text', text: summary }] };
   }

--- a/tests/unit/tools/features/create-feature.test.ts
+++ b/tests/unit/tools/features/create-feature.test.ts
@@ -6,7 +6,11 @@ import { Logger } from '@utils/logger';
 /** Parse the MCP content wrapper to get the underlying result */
 function parseResult(result: any): any {
   if (result?.content?.[0]?.text) {
-    try { return JSON.parse(result.content[0].text); } catch { return result.content[0].text; }
+    try {
+      return JSON.parse(result.content[0].text);
+    } catch {
+      return result.content[0].text;
+    }
   }
   return result;
 }
@@ -24,14 +28,14 @@ describe('CreateFeatureTool', () => {
       delete: jest.fn(),
       patch: jest.fn(),
     } as unknown as jest.Mocked<ProductboardAPIClient>;
-    
+
     mockLogger = {
       info: jest.fn(),
       debug: jest.fn(),
       error: jest.fn(),
       warn: jest.fn(),
     } as any;
-    
+
     tool = new CreateFeatureTool(mockClient, mockLogger);
   });
 
@@ -67,7 +71,9 @@ describe('CreateFeatureTool', () => {
     it('should validate required fields', async () => {
       await expect(tool.execute({} as any)).rejects.toThrow('Invalid parameters');
       await expect(tool.execute({ name: 'Test' } as any)).rejects.toThrow('Invalid parameters');
-      await expect(tool.execute({ description: 'Test' } as any)).rejects.toThrow('Invalid parameters');
+      await expect(tool.execute({ description: 'Test' } as any)).rejects.toThrow(
+        'Invalid parameters',
+      );
     });
 
     it('should validate email format', async () => {
@@ -84,6 +90,7 @@ describe('CreateFeatureTool', () => {
       const input = {
         name: 'Test Feature',
         description: 'Test description',
+        component_id: 'comp_456',
         status: 'invalid_status',
       } as any;
       mockClient.post.mockResolvedValueOnce({ id: 'feat_1', name: 'Test Feature' });
@@ -121,6 +128,16 @@ describe('CreateFeatureTool', () => {
       const validation = tool.validateParams(validInput);
       expect(validation.valid).toBe(true);
     });
+
+    it('should require a parent product or component', () => {
+      const validation = tool.validateParams({
+        name: 'User Authentication Feature',
+        description: 'Implement OAuth2 authentication for mobile app',
+      });
+
+      expect(validation.valid).toBe(false);
+      expect(validation.errors[0].message).toContain('Either product_id or component_id');
+    });
   });
 
   describe('execute', () => {
@@ -147,7 +164,7 @@ describe('CreateFeatureTool', () => {
         created_at: '2024-01-15T10:00:00Z',
         updated_at: '2024-01-20T14:30:00Z',
       };
-      
+
       mockClient.post.mockResolvedValueOnce(expectedResponse);
 
       const result = parseResult(await tool.execute(validInput));
@@ -158,7 +175,7 @@ describe('CreateFeatureTool', () => {
           fields: {
             name: validInput.name,
             description: `<p>${validInput.description}</p>`,
-            tags: validInput.tags,
+            tags: validInput.tags.map((name) => ({ name })),
             priority: validInput.priority,
             owner: { email: validInput.owner_email },
           },
@@ -175,6 +192,7 @@ describe('CreateFeatureTool', () => {
       const validInput = {
         name: 'User Authentication Feature',
         description: 'Implement OAuth2 authentication for mobile app',
+        component_id: 'comp_456',
       };
 
       mockClient.post.mockRejectedValueOnce(new Error('API Error'));
@@ -188,6 +206,7 @@ describe('CreateFeatureTool', () => {
       const validInput = {
         name: 'User Authentication Feature',
         description: 'Implement OAuth2 authentication for mobile app',
+        component_id: 'comp_456',
       };
 
       const error = new Error('Authentication failed');
@@ -203,6 +222,7 @@ describe('CreateFeatureTool', () => {
       const validInput = {
         name: 'User Authentication Feature',
         description: 'Implement OAuth2 authentication for mobile app',
+        component_id: 'comp_456',
       };
 
       const error = new Error('Validation error');
@@ -219,6 +239,7 @@ describe('CreateFeatureTool', () => {
       const validInput = {
         name: 'User Authentication Feature',
         description: 'Implement OAuth2 authentication for mobile app',
+        component_id: 'comp_456',
       };
 
       const result = parseResult(await uninitializedTool.execute(validInput));
@@ -229,6 +250,7 @@ describe('CreateFeatureTool', () => {
       const inputWithoutStatus = {
         name: 'User Authentication Feature',
         description: 'Implement OAuth2 authentication for mobile app',
+        component_id: 'comp_456',
       };
 
       const expectedResponse = {
@@ -251,6 +273,7 @@ describe('CreateFeatureTool', () => {
             name: inputWithoutStatus.name,
             description: `<p>${inputWithoutStatus.description}</p>`,
           },
+          relationships: [{ type: 'parent', target: { id: inputWithoutStatus.component_id } }],
         },
       });
     });
@@ -269,10 +292,13 @@ describe('CreateFeatureTool', () => {
 
       mockClient.post.mockResolvedValueOnce(apiResponse);
 
-      const result = parseResult(await tool.execute({
-        name: 'Test Feature',
-        description: 'Test Description',
-      }));
+      const result = parseResult(
+        await tool.execute({
+          name: 'Test Feature',
+          description: 'Test Description',
+          component_id: 'comp_456',
+        }),
+      );
 
       expect(result).toEqual({
         success: true,

--- a/tests/unit/tools/features/update-feature.test.ts
+++ b/tests/unit/tools/features/update-feature.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { UpdateFeatureTool } from '@tools/features/update-feature';
+import { ProductboardAPIClient } from '@api/client';
+import { Logger } from '@utils/logger';
+
+function parseResult(result: any): any {
+  if (result?.content?.[0]?.text) {
+    try {
+      return JSON.parse(result.content[0].text);
+    } catch {
+      return result.content[0].text;
+    }
+  }
+  return result;
+}
+
+describe('UpdateFeatureTool', () => {
+  let tool: UpdateFeatureTool;
+  let mockClient: jest.Mocked<ProductboardAPIClient>;
+  let mockLogger: jest.Mocked<Logger>;
+
+  beforeEach(() => {
+    mockClient = {
+      post: jest.fn(),
+      get: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+      patch: jest.fn(),
+    } as unknown as jest.Mocked<ProductboardAPIClient>;
+
+    mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+    } as any;
+
+    tool = new UpdateFeatureTool(mockClient, mockLogger);
+  });
+
+  it('should have correct name and description', () => {
+    expect(tool.name).toBe('pb_feature_update');
+    expect(tool.description).toBe('Update an existing feature');
+  });
+
+  it('should require an id and at least one update field', async () => {
+    await expect(tool.execute({} as any)).rejects.toThrow('Invalid parameters');
+    await expect(tool.execute({ id: 'feat_123' } as any)).rejects.toThrow('Invalid parameters');
+  });
+
+  it('should PATCH description as Productboard rich text fields payload', async () => {
+    mockClient.patch.mockResolvedValueOnce({ data: { id: 'feat_123' } });
+
+    const result = parseResult(
+      await tool.execute({
+        id: 'feat_123',
+        description: 'Full description with details',
+      }),
+    );
+
+    expect(mockClient.patch).toHaveBeenCalledWith('/entities/feat_123', {
+      data: {
+        fields: {
+          description: '<p>Full description with details</p>',
+        },
+      },
+    });
+    expect(result).toEqual({ success: true, data: { id: 'feat_123' } });
+  });
+
+  it('should preserve HTML descriptions instead of double-wrapping them', async () => {
+    mockClient.patch.mockResolvedValueOnce({ data: { id: 'feat_123' } });
+
+    await tool.execute({ id: 'feat_123', description: '<p>Already HTML</p>' });
+
+    expect(mockClient.patch).toHaveBeenCalledWith('/entities/feat_123', {
+      data: { fields: { description: '<p>Already HTML</p>' } },
+    });
+  });
+
+  it('should map owner, status, and tags to Productboard update field formats', async () => {
+    mockClient.patch.mockResolvedValueOnce({ data: { id: 'feat_123' } });
+
+    await tool.execute({
+      id: 'feat_123',
+      owner_email: 'owner@example.com',
+      status_id: 'status_123',
+      tags: ['api', 'customer-feedback'],
+    });
+
+    expect(mockClient.patch).toHaveBeenCalledWith('/entities/feat_123', {
+      data: {
+        fields: {
+          owner: { email: 'owner@example.com' },
+          status: { id: 'status_123' },
+          tags: [{ name: 'api' }, { name: 'customer-feedback' }],
+        },
+      },
+    });
+  });
+
+  it('should surface API errors as failed tool results', async () => {
+    mockClient.patch.mockRejectedValueOnce(new Error('API Error'));
+
+    const result = parseResult(await tool.execute({ id: 'feat_123', description: 'Update' }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/tests/unit/tools/objectives/list-objectives.test.ts
+++ b/tests/unit/tools/objectives/list-objectives.test.ts
@@ -12,12 +12,22 @@ describe('ListObjectivesTool', () => {
   const mockObjectives = [
     {
       id: 'obj_123',
-      fields: { name: 'Increase User Engagement', description: 'Improve engagement', status: { name: 'active' }, owner: { email: 'jane@example.com' } },
+      fields: {
+        name: 'Increase User Engagement',
+        description: 'Improve engagement',
+        status: { name: 'active' },
+        owner: { email: 'jane@example.com' },
+      },
       createdAt: '2024-01-15T10:00:00Z',
     },
     {
       id: 'obj_456',
-      fields: { name: 'Reduce Churn Rate', description: 'Decrease churn', status: { name: 'active' }, owner: { email: 'john@example.com' } },
+      fields: {
+        name: 'Reduce Churn Rate',
+        description: 'Decrease churn',
+        status: { name: 'active' },
+        owner: { email: 'john@example.com' },
+      },
       createdAt: '2024-01-10T10:00:00Z',
     },
   ];
@@ -94,15 +104,21 @@ describe('ListObjectivesTool', () => {
     });
 
     it('should validate status enum', async () => {
-      await expect(tool.execute({ status: 'invalid_status' } as any)).rejects.toThrow('Invalid parameters');
+      await expect(tool.execute({ status: 'invalid_status' } as any)).rejects.toThrow(
+        'Invalid parameters',
+      );
     });
 
     it('should validate period enum', async () => {
-      await expect(tool.execute({ period: 'invalid_period' } as any)).rejects.toThrow('Invalid parameters');
+      await expect(tool.execute({ period: 'invalid_period' } as any)).rejects.toThrow(
+        'Invalid parameters',
+      );
     });
 
     it('should validate email format', async () => {
-      await expect(tool.execute({ owner_email: 'invalid-email' } as any)).rejects.toThrow('Invalid parameters');
+      await expect(tool.execute({ owner_email: 'invalid-email' } as any)).rejects.toThrow(
+        'Invalid parameters',
+      );
     });
 
     it('should validate limit range', async () => {
@@ -170,7 +186,10 @@ describe('ListObjectivesTool', () => {
 
       const result = await tool.execute(input);
 
-      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', { 'type[]': 'objective', status: 'completed' });
+      expect(mockClient.getAllPages).toHaveBeenCalledWith('/entities', {
+        'type[]': 'objective',
+        status: 'completed',
+      });
 
       expect(result.content[0].text).toBe('No objectives found.');
     });
@@ -213,7 +232,11 @@ describe('ListObjectivesTool', () => {
       const apiResponse = [
         {
           id: 'obj_123',
-          fields: { name: 'Test Objective', description: 'Test Description', status: { name: 'active' } },
+          fields: {
+            name: 'Test Objective',
+            description: 'Test Description',
+            status: { name: 'active' },
+          },
           createdAt: '2024-01-01T00:00:00Z',
         },
       ];
@@ -225,6 +248,24 @@ describe('ListObjectivesTool', () => {
       expect(result.content[0].type).toBe('text');
       expect(result.content[0].text).toContain('Test Objective');
       expect(result.content[0].text).toContain('Found 1 objectives');
+    });
+
+    it('should return full objective descriptions without truncating core context', async () => {
+      const longDescription = `<p>${'Detailed objective context. '.repeat(20)}</p>`;
+      mockClient.getAllPages.mockResolvedValueOnce([
+        {
+          id: 'obj_long',
+          fields: {
+            name: 'Context-heavy Objective',
+            description: longDescription,
+            status: { name: 'active' },
+          },
+        },
+      ]);
+
+      const result = await tool.execute({});
+
+      expect(result.content[0].text).toContain('Detailed objective context. '.repeat(20).trim());
     });
 
     it('should handle empty results', async () => {


### PR DESCRIPTION
## Summary
- require a parent product/component for `pb_feature_create` before calling Productboard, avoiding the known 400 on parentless feature creation
- map feature tags to Productboard `{ name }` assignment objects on create/update
- add `pb_feature_update` regression coverage for description, owner, status, and tags
- stop truncating objective descriptions in `pb_objective_list` so core OKR context is preserved
- narrow the Ajv override so ESLint can run with its expected Ajv v6 while runtime deps keep Ajv v8

Fixes #35.
Refs #37.

## Verification
- `npm test -- --runInBand` ✅
- `npm run build` ✅
- `npm run lint` runs now but still fails on existing strict TypeScript lint debt across the repo (not introduced here).
